### PR TITLE
Release version 2.5.0

### DIFF
--- a/.yarddoc-files
+++ b/.yarddoc-files
@@ -13,6 +13,7 @@ lib/oci/key_management/key_management.rb
 lib/oci/load_balancer/load_balancer.rb
 lib/oci/object_storage/object_storage.rb
 lib/oci/resource_search/resource_search.rb
+lib/oci/streaming/streaming.rb
 lib/oci/waas/waas.rb
 lib/
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.5.0 - 2019-02-21
+### Added
+- Support for government-realm regions
+- Support for the Streaming service
+- Support for tags in the Key Management service
+- Support for regional subnets in the Virtual Networking service
+- Support for specifying an optional `endpoint` parameter when creating a new client
+
+### Fixed
+- Removed unused Announcements service `OCI::AnnouncementsService::Models::NotificationFollowupDetails` model and `followups` from `OCI::AnnouncementsService::Models::Announcement`
+
+
 ## 2.4.7 - 2019-02-07
 ### Added
 - Support for the Web Application Acceleration and Security (WAAS) service

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Oracle Cloud Infrastructure Ruby SDK
-**Version 2.4.7**
+**Version 2.5.0**
 
 This topic describes how to install, configure, and use the Oracle Cloud Infrastructure Ruby SDK.
 
@@ -21,6 +21,7 @@ The Ruby SDK supports the following services:
 * Load Balancing
 * Object Storage
 * Search
+* Streaming
 * Web Application Acceleration and Security
 
 **Licensing:** This SDK and sample is dual licensed under the Universal Permissive License 1.0 and the Apache License.
@@ -166,6 +167,22 @@ Note that the Ruby SDK does not support parsing custom attributes in the configu
 ## Forward Compatibility
 
 Some response fields are enum-typed. In the future, individual services may return values not covered by existing enums for that field. To address this possibility, every enum-type response field has an additional value named "UNKNOWN_ENUM_VALUE". If a service returns a value that is not recognized by your version of the SDK, then the response field will be set to this value. Please ensure that your code handles the "UNKNOWN_ENUM_VALUE" case if you have conditional logic based on an enum-typed field.
+
+## New Region Support
+
+If you are using a version of the SDK released prior to the announcement of a new region, you may still be able to reach it, depending on whether the region is in the oraclecloud.com realm.
+
+A *region* is a localized geographic area. For more information on regions and how to identify them, see [Regions and Availability Domains](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/regions.htm).
+
+A *realm* is a set of regions that share entities. You can identify your realm by looking at the domain name at the end of the network address. For example, the realm for ``xyz.abc.123.oraclecloud.com`` is ``oraclecloud.com``.
+
+### oraclecloud.com Realm
+
+For regions in the oraclecloud.com realm, even if the `OCI::Regions::REGION_ENUM` does not contain the new region, the forward compatibility of the SDK can automatically handle it. You can pass new region names just as you would pass ones that are already defined. For more information on passing region names in the configuration, see [Configuring the SDK](#configuring-the-sdk). For details on `OCI::Regions::REGION_ENUM`, see [OCI::Regions](https://docs.cloud.oracle.com/iaas/tools/ruby/latest/OCI/Regions.html).
+
+### Other Realms
+
+Accessing regions in realms other than oraclecloud.com with prior versions of the Ruby SDK is currently unsupported. We recommend moving to a version that explicitly supports the desired region.
 
 ## Writing Your First Ruby Program with the SDK
 

--- a/lib/oci.rb
+++ b/lib/oci.rb
@@ -33,6 +33,7 @@ require 'oci/key_management/key_management'
 require 'oci/announcements_service/announcements_service'
 require 'oci/waas/waas'
 require 'oci/healthchecks/healthchecks'
+require 'oci/streaming/streaming'
 
 # Top level module for the Oracle Cloud Infrastructure SDK
 module OCI

--- a/lib/oci/announcements_service/announcements_service.rb
+++ b/lib/oci/announcements_service/announcements_service.rb
@@ -16,7 +16,6 @@ require 'oci/announcements_service/models/announcement_summary'
 require 'oci/announcements_service/models/announcement_user_status_details'
 require 'oci/announcements_service/models/announcements_collection'
 require 'oci/announcements_service/models/base_announcement'
-require 'oci/announcements_service/models/notification_followup_details'
 
 # Require generated clients
 require 'oci/announcements_service/announcement_client'

--- a/lib/oci/announcements_service/models/affected_resource.rb
+++ b/lib/oci/announcements_service/models/affected_resource.rb
@@ -4,18 +4,18 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # Descrption of a resource affected by the announcement
+  # The resource affected by the event described in the announcement.
   #
   class AnnouncementsService::Models::AffectedResource # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the resource
+    # **[Required]** The OCID of the affected resource.
     # @return [String]
     attr_accessor :resource_id
 
-    # **[Required]** User-friendly name of the resource
+    # **[Required]** The friendly name of the resource.
     # @return [String]
     attr_accessor :resource_name
 
-    # **[Required]** Region where this resource belongs to
+    # **[Required]** The region where the affected resource exists.
     # @return [String]
     attr_accessor :region
 

--- a/lib/oci/announcements_service/models/announcement.rb
+++ b/lib/oci/announcements_service/models/announcement.rb
@@ -6,21 +6,23 @@ require_relative 'base_announcement'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # An announcement object which represents a message targetted to a specific tenant
+  # A message about an impactful operational event.
   #
   class AnnouncementsService::Models::Announcement < AnnouncementsService::Models::BaseAnnouncement # rubocop:disable Metrics/LineLength
-    # A more detailed explanation of the notification. A markdown format input
+    # A detailed explanation of the event, expressed by using Markdown language. Avoid entering
+    # confidential information.
+    #
     # @return [String]
     attr_accessor :description
 
-    # A markdown format input that forms e.g. the FAQ section of a notification
+    # Additional information about the event, expressed by using Markdown language and included in the
+    # details view of an announcement. Additional information might include remediation steps or
+    # answers to frequently asked questions. Avoid entering confidential information.
+    #
     # @return [String]
     attr_accessor :additional_information
 
-    # @return [Array<OCI::AnnouncementsService::Models::NotificationFollowupDetails>]
-    attr_accessor :followups
-
-    # List of resources (possibly empty) affected by this announcement
+    # The list of resources, if any, affected by the event described in the announcement.
     # @return [Array<OCI::AnnouncementsService::Models::AffectedResource>]
     attr_accessor :affected_resources
 
@@ -45,7 +47,6 @@ module OCI
         'time_updated': :'timeUpdated',
         'description': :'description',
         'additional_information': :'additionalInformation',
-        'followups': :'followups',
         'affected_resources': :'affectedResources'
         # rubocop:enable Style/SymbolLiteral
       }
@@ -72,7 +73,6 @@ module OCI
         'time_updated': :'DateTime',
         'description': :'String',
         'additional_information': :'String',
-        'followups': :'Array<OCI::AnnouncementsService::Models::NotificationFollowupDetails>',
         'affected_resources': :'Array<OCI::AnnouncementsService::Models::AffectedResource>'
         # rubocop:enable Style/SymbolLiteral
       }
@@ -100,7 +100,6 @@ module OCI
     # @option attributes [DateTime] :time_updated The value to assign to the {OCI::AnnouncementsService::Models::BaseAnnouncement#time_updated #time_updated} proprety
     # @option attributes [String] :description The value to assign to the {#description} property
     # @option attributes [String] :additional_information The value to assign to the {#additional_information} property
-    # @option attributes [Array<OCI::AnnouncementsService::Models::NotificationFollowupDetails>] :followups The value to assign to the {#followups} property
     # @option attributes [Array<OCI::AnnouncementsService::Models::AffectedResource>] :affected_resources The value to assign to the {#affected_resources} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
@@ -119,8 +118,6 @@ module OCI
       raise 'You cannot provide both :additionalInformation and :additional_information' if attributes.key?(:'additionalInformation') && attributes.key?(:'additional_information')
 
       self.additional_information = attributes[:'additional_information'] if attributes[:'additional_information']
-
-      self.followups = attributes[:'followups'] if attributes[:'followups']
 
       self.affected_resources = attributes[:'affectedResources'] if attributes[:'affectedResources']
 
@@ -157,7 +154,6 @@ module OCI
         time_updated == other.time_updated &&
         description == other.description &&
         additional_information == other.additional_information &&
-        followups == other.followups &&
         affected_resources == other.affected_resources
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
@@ -174,7 +170,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [id, type, reference_ticket_number, summary, time_one_title, time_one_value, time_two_title, time_two_value, services, affected_regions, announcement_type, lifecycle_state, is_banner, time_created, time_updated, description, additional_information, followups, affected_resources].hash
+      [id, type, reference_ticket_number, summary, time_one_title, time_one_value, time_two_title, time_two_value, services, affected_regions, announcement_type, lifecycle_state, is_banner, time_created, time_updated, description, additional_information, affected_resources].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/announcements_service/models/announcement_summary.rb
+++ b/lib/oci/announcements_service/models/announcement_summary.rb
@@ -6,7 +6,7 @@ require_relative 'base_announcement'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # An announcement summary object which is returned by List API
+  # Summary representation of an announcement.
   #
   class AnnouncementsService::Models::AnnouncementSummary < AnnouncementsService::Models::BaseAnnouncement # rubocop:disable Metrics/LineLength
     # Attribute mapping from ruby-style variable name to JSON key.

--- a/lib/oci/announcements_service/models/announcement_user_status_details.rb
+++ b/lib/oci/announcements_service/models/announcement_user_status_details.rb
@@ -4,19 +4,19 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # An announcement status
+  # An announcement's status regarding whether it has been acknowledged by a user.
   #
   class AnnouncementsService::Models::AnnouncementUserStatusDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the announcement this status belongs to
+    # **[Required]** The OCID of the announcement that this status is associated with.
     # @return [String]
     attr_accessor :user_status_announcement_id
 
-    # **[Required]** The OCID of the user this status belongs to
+    # **[Required]** The OCID of the user that this status is associated with.
     # @return [String]
     attr_accessor :user_id
 
-    # The date and time the announcement was acknowledged, in the format defined by RFC3339
-    # Example: `2016-07-22T17:43:01.389+0000`
+    # The date and time the announcement was acknowledged, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
+    # Example: `2019-01-01T17:43:01.389+0000`
     #
     # @return [DateTime]
     attr_accessor :time_acknowledged

--- a/lib/oci/announcements_service/models/announcements_collection.rb
+++ b/lib/oci/announcements_service/models/announcements_collection.rb
@@ -4,14 +4,14 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # Results of annoucements search. Contains both announcements, and user specific status of the announcments
+  # A list of announcements that match filter criteria, if any. Results contain both the announcements and the user-specific status of the announcements.
   #
   class AnnouncementsService::Models::AnnouncementsCollection # rubocop:disable Metrics/LineLength
-    # collection of announcements
+    # A collection of announcements.
     # @return [Array<OCI::AnnouncementsService::Models::AnnouncementSummary>]
     attr_accessor :items
 
-    # user specific status of found announcements
+    # The user-specific status for found announcements.
     # @return [Array<OCI::AnnouncementsService::Models::AnnouncementUserStatusDetails>]
     attr_accessor :user_statuses
 

--- a/lib/oci/announcements_service/models/base_announcement.rb
+++ b/lib/oci/announcements_service/models/base_announcement.rb
@@ -4,7 +4,7 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # Base for announcements and incidents
+  # Incident information that forms the basis of an announcement. Avoid entering confidential information.
   # This class has direct subclasses. If you are using this class as input to a service operations then you should favor using a subclass over the base class
   class AnnouncementsService::Models::BaseAnnouncement # rubocop:disable Metrics/LineLength
     ANNOUNCEMENT_TYPE_ENUM = [
@@ -29,66 +29,76 @@ module OCI
       LIFECYCLE_STATE_INACTIVE = 'INACTIVE'.freeze
     ].freeze
 
-    # **[Required]** The OCID of the announcement
+    # **[Required]** The OCID of the announcement.
     # @return [String]
     attr_accessor :id
 
-    # **[Required]** Entity type
+    # **[Required]** The entity type.
     # @return [String]
     attr_accessor :type
 
-    # **[Required]** The reference JIRA ticket number
+    # **[Required]** The reference Jira ticket number.
     # @return [String]
     attr_accessor :reference_ticket_number
 
-    # **[Required]** Forms part of the email subject and/or the console representation (a banner or alike)
+    # **[Required]** A summary of the issue. A summary might appear in the console banner view of the announcement or in
+    # an email subject line. Avoid entering confidential information.
+    #
     # @return [String]
     attr_accessor :summary
 
-    # The title of the first time value, e.g. Time Started
+    # The label associated with an initial time value.
+    # Example: `Time Started`
+    #
     # @return [String]
     attr_accessor :time_one_title
 
-    # The first time value, actual meaning depending on notification type
+    # The actual value of the first time value for the event. Typically, this is the time an event started, but the meaning
+    # can vary, depending on the announcement type.
+    #
     # @return [DateTime]
     attr_accessor :time_one_value
 
-    # The title of the second time value, e.g. Time Ended
+    # The label associated with a second time value.
+    # Example: `Time Ended`
+    #
     # @return [String]
     attr_accessor :time_two_title
 
-    # The second time value, actual meaning depending on notification type
+    # The actual value of the second time value. Typically, this is the time an event ended, but the meaning
+    # can vary, depending on the announcement type.
+    #
     # @return [DateTime]
     attr_accessor :time_two_value
 
-    # Impacted services
+    # **[Required]** Impacted Oracle Cloud Infrastructure services.
     # @return [Array<String>]
     attr_accessor :services
 
-    # Impacted regions
+    # **[Required]** Impacted regions.
     # @return [Array<String>]
     attr_accessor :affected_regions
 
-    # **[Required]** The detailed description of an announcement
+    # **[Required]** The type of announcement. An announcement's type signals its severity.
     # @return [String]
     attr_reader :announcement_type
 
-    # **[Required]** Lifecycle states of announcement
+    # **[Required]** The current lifecycle state of the announcement.
     # @return [String]
     attr_reader :lifecycle_state
 
-    # **[Required]** Show announcement as a banner
+    # **[Required]** Whether the announcement is displayed as a banner in the console.
     # @return [BOOLEAN]
     attr_accessor :is_banner
 
-    # The date and time the announcement was created, in the format defined by RFC3339
-    # Example: `2016-07-22T17:43:01.389+0000`
+    # The date and time the announcement was created, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
+    # Example: `2019-01-01T17:43:01.389+0000`
     #
     # @return [DateTime]
     attr_accessor :time_created
 
-    # The date and time the announcement was last updated, in the format defined by RFC3339
-    # Example: `2016-07-22T17:43:01.389+0000`
+    # The date and time the announcement was last updated, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
+    # Example: `2019-01-01T17:43:01.389+0000`
     #
     # @return [DateTime]
     attr_accessor :time_updated

--- a/lib/oci/audit/audit_client.rb
+++ b/lib/oci/audit/audit_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new AuditClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20160918'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "AuditClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :AuditClient) + '/20160918'
-      logger.info "AuditClient endpoint set to '#{endpoint}'." if logger
+      logger.info "AuditClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/container_engine/container_engine_client.rb
+++ b/lib/oci/container_engine/container_engine_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new ContainerEngineClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20180222'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "ContainerEngineClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :ContainerEngineClient) + '/20180222'
-      logger.info "ContainerEngineClient endpoint set to '#{endpoint}'." if logger
+      logger.info "ContainerEngineClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/core/blockstorage_client.rb
+++ b/lib/oci/core/blockstorage_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new BlockstorageClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20160918'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "BlockstorageClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :BlockstorageClient) + '/20160918'
-      logger.info "BlockstorageClient endpoint set to '#{endpoint}'." if logger
+      logger.info "BlockstorageClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/core/compute_client.rb
+++ b/lib/oci/core/compute_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new ComputeClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20160918'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "ComputeClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :ComputeClient) + '/20160918'
-      logger.info "ComputeClient endpoint set to '#{endpoint}'." if logger
+      logger.info "ComputeClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/core/compute_management_client.rb
+++ b/lib/oci/core/compute_management_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new ComputeManagementClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20160918'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "ComputeManagementClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :ComputeManagementClient) + '/20160918'
-      logger.info "ComputeManagementClient endpoint set to '#{endpoint}'." if logger
+      logger.info "ComputeManagementClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/core/models/create_subnet_details.rb
+++ b/lib/oci/core/models/create_subnet_details.rb
@@ -6,7 +6,7 @@ require 'date'
 module OCI
   # CreateSubnetDetails model.
   class Core::Models::CreateSubnetDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The availability domain to contain the subnet.
+    # The availability domain to contain the subnet.
     #
     # Example: `Uocm:PHX-AD-1`
     #

--- a/lib/oci/core/models/subnet.rb
+++ b/lib/oci/core/models/subnet.rb
@@ -27,7 +27,7 @@ module OCI
       LIFECYCLE_STATE_UNKNOWN_ENUM_VALUE = 'UNKNOWN_ENUM_VALUE'.freeze
     ].freeze
 
-    # **[Required]** The subnet's availability domain.
+    # The subnet's availability domain.
     #
     # Example: `Uocm:PHX-AD-1`
     #

--- a/lib/oci/database/database_client.rb
+++ b/lib/oci/database/database_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new DatabaseClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20160918'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "DatabaseClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :DatabaseClient) + '/20160918'
-      logger.info "DatabaseClient endpoint set to '#{endpoint}'." if logger
+      logger.info "DatabaseClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/dns/dns_client.rb
+++ b/lib/oci/dns/dns_client.rb
@@ -26,20 +26,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new DnsClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -48,7 +50,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -74,11 +76,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20180115'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "DnsClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -89,7 +96,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :DnsClient) + '/20180115'
-      logger.info "DnsClient endpoint set to '#{endpoint}'." if logger
+      logger.info "DnsClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/file_storage/file_storage_client.rb
+++ b/lib/oci/file_storage/file_storage_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new FileStorageClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20171215'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "FileStorageClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :FileStorageClient) + '/20171215'
-      logger.info "FileStorageClient endpoint set to '#{endpoint}'." if logger
+      logger.info "FileStorageClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/healthchecks/health_checks_client.rb
+++ b/lib/oci/healthchecks/health_checks_client.rb
@@ -27,20 +27,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new HealthChecksClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -49,7 +51,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -75,11 +77,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20180501'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "HealthChecksClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -90,7 +97,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :HealthChecksClient) + '/20180501'
-      logger.info "HealthChecksClient endpoint set to '#{endpoint}'." if logger
+      logger.info "HealthChecksClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/identity/identity_client.rb
+++ b/lib/oci/identity/identity_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new IdentityClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20160918'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "IdentityClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :IdentityClient) + '/20160918'
-      logger.info "IdentityClient endpoint set to '#{endpoint}'." if logger
+      logger.info "IdentityClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/key_management/kms_crypto_client.rb
+++ b/lib/oci/key_management/kms_crypto_client.rb
@@ -21,14 +21,14 @@ module OCI
     # @return [OCI::Retry::RetryConfig]
     attr_reader :retry_config
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new KmsCryptoClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
-    #   This client is not thread-safe
     #
+    #   This client is not thread-safe
     # @param [Config] config A Config object.
     # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
@@ -39,7 +39,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, endpoint:, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       raise 'A fully qualified endpoint URL must be defined' unless endpoint
 
       @endpoint = endpoint + '/20180608'
@@ -68,10 +68,9 @@ module OCI
 
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
-
       logger.info "KmsCryptoClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # @return [Logger] The logger for this client. May be nil.
     def logger

--- a/lib/oci/key_management/kms_management_client.rb
+++ b/lib/oci/key_management/kms_management_client.rb
@@ -21,14 +21,14 @@ module OCI
     # @return [OCI::Retry::RetryConfig]
     attr_reader :retry_config
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new KmsManagementClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
-    #   This client is not thread-safe
     #
+    #   This client is not thread-safe
     # @param [Config] config A Config object.
     # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
@@ -39,7 +39,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, endpoint:, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       raise 'A fully qualified endpoint URL must be defined' unless endpoint
 
       @endpoint = endpoint + '/20180608'
@@ -68,10 +68,9 @@ module OCI
 
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
-
       logger.info "KmsManagementClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # @return [Logger] The logger for this client. May be nil.
     def logger
@@ -643,9 +642,9 @@ module OCI
     # rubocop:disable Metrics/MethodLength, Layout/EmptyLines
 
 
-    # Updates the properties of a key. Specifically, you can
-    # only update the `displayName` property. Furthermore, the
-    # key must in an `ACTIVE` or `CREATING` state.
+    # Updates the properties of a key. Specifically, you can update the
+    # `displayName` , `freeformTags`, and `definedTags` properties. Furthermore,
+    # the key must in an `ACTIVE` or `CREATING` state.
     #
     # @param [String] key_id The OCID of the key.
     # @param [OCI::KeyManagement::Models::UpdateKeyDetails] update_key_details UpdateKeyDetails

--- a/lib/oci/key_management/kms_vault_client.rb
+++ b/lib/oci/key_management/kms_vault_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new KmsVaultClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20180608'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "KmsVaultClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :KmsVaultClient) + '/20180608'
-      logger.info "KmsVaultClient endpoint set to '#{endpoint}'." if logger
+      logger.info "KmsVaultClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.
@@ -459,9 +466,9 @@ module OCI
     # rubocop:disable Metrics/MethodLength, Layout/EmptyLines
 
 
-    # Updates the properties of a vault. Specifically, you can
-    # only update the `displayName` property. Furthermore, the vault
-    # must be in an `ACTIVE` or `CREATING` state.
+    # Updates the properties of a vault. Specifically, you can update the
+    # `displayName` , `freeformTags`, and `definedTags` properties. Furthermore,
+    # the vault must be in an `ACTIVE` or `CREATING` state.
     #
     # @param [String] vault_id The OCID of the vault.
     # @param [OCI::KeyManagement::Models::UpdateVaultDetails] update_vault_details UpdateVaultDetails

--- a/lib/oci/key_management/models/key_version.rb
+++ b/lib/oci/key_management/models/key_version.rb
@@ -20,7 +20,7 @@ module OCI
 
     # **[Required]** The date and time this key version was created, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
     #
-    # Example: `2018-04-03T21:10:29.600Z`
+    # Example: \"2018-04-03T21:10:29.600Z\"
     #
     # @return [DateTime]
     attr_accessor :time_created

--- a/lib/oci/key_management/models/update_key_details.rb
+++ b/lib/oci/key_management/models/update_key_details.rb
@@ -6,17 +6,32 @@ require 'date'
 module OCI
   # UpdateKeyDetails model.
   class KeyManagement::Models::UpdateKeyDetails # rubocop:disable Metrics/LineLength
+    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+    #
+    # @return [Hash<String, Hash<String, Object>>]
+    attr_accessor :defined_tags
+
     # A user-friendly name for the key. It does not have to be unique, and it is changeable.
     # Avoid entering confidential information.
     #
     # @return [String]
     attr_accessor :display_name
 
+    # Simple key-value pair that is applied without any predefined name, type, or scope.
+    # Exists for cross-compatibility only.
+    # Example: `{\"bar-key\": \"value\"}`
+    #
+    # @return [Hash<String, String>]
+    attr_accessor :freeform_tags
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'display_name': :'displayName'
+        'defined_tags': :'definedTags',
+        'display_name': :'displayName',
+        'freeform_tags': :'freeformTags'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -25,7 +40,9 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'display_name': :'String'
+        'defined_tags': :'Hash<String, Hash<String, Object>>',
+        'display_name': :'String',
+        'freeform_tags': :'Hash<String, String>'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -36,18 +53,32 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
+    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
     # @option attributes [String] :display_name The value to assign to the {#display_name} property
+    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
+      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+
+      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+
+      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
+
       self.display_name = attributes[:'displayName'] if attributes[:'displayName']
 
       raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
 
       self.display_name = attributes[:'display_name'] if attributes[:'display_name']
+
+      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
+
+      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
+
+      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -61,7 +92,9 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        display_name == other.display_name
+        defined_tags == other.defined_tags &&
+        display_name == other.display_name &&
+        freeform_tags == other.freeform_tags
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -77,7 +110,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [display_name].hash
+      [defined_tags, display_name, freeform_tags].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/key_management/models/update_vault_details.rb
+++ b/lib/oci/key_management/models/update_vault_details.rb
@@ -6,17 +6,32 @@ require 'date'
 module OCI
   # UpdateVaultDetails model.
   class KeyManagement::Models::UpdateVaultDetails # rubocop:disable Metrics/LineLength
+    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+    #
+    # @return [Hash<String, Hash<String, Object>>]
+    attr_accessor :defined_tags
+
     # A user-friendly name for the vault. It does not have to be unique, and it is changeable.
     # Avoid entering confidential information.
     #
     # @return [String]
     attr_accessor :display_name
 
+    # Simple key-value pair that is applied without any predefined name, type, or scope.
+    # Exists for cross-compatibility only.
+    # Example: `{\"bar-key\": \"value\"}`
+    #
+    # @return [Hash<String, String>]
+    attr_accessor :freeform_tags
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'display_name': :'displayName'
+        'defined_tags': :'definedTags',
+        'display_name': :'displayName',
+        'freeform_tags': :'freeformTags'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -25,7 +40,9 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'display_name': :'String'
+        'defined_tags': :'Hash<String, Hash<String, Object>>',
+        'display_name': :'String',
+        'freeform_tags': :'Hash<String, String>'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -36,18 +53,32 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
+    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
     # @option attributes [String] :display_name The value to assign to the {#display_name} property
+    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
+      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+
+      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+
+      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
+
       self.display_name = attributes[:'displayName'] if attributes[:'displayName']
 
       raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
 
       self.display_name = attributes[:'display_name'] if attributes[:'display_name']
+
+      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
+
+      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
+
+      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -61,7 +92,9 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        display_name == other.display_name
+        defined_tags == other.defined_tags &&
+        display_name == other.display_name &&
+        freeform_tags == other.freeform_tags
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -77,7 +110,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [display_name].hash
+      [defined_tags, display_name, freeform_tags].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/load_balancer/load_balancer_client.rb
+++ b/lib/oci/load_balancer/load_balancer_client.rb
@@ -26,20 +26,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new LoadBalancerClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -48,7 +50,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -74,11 +76,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20170115'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "LoadBalancerClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -89,7 +96,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint_for_template(@region, 'https://iaas.{region}.oraclecloud.com') + '/20170115'
-      logger.info "LoadBalancerClient endpoint set to '#{endpoint}'." if logger
+      logger.info "LoadBalancerClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/object_storage/object_storage_client.rb
+++ b/lib/oci/object_storage/object_storage_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new ObjectStorageClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "ObjectStorageClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :ObjectStorageClient) + '/'
-      logger.info "ObjectStorageClient endpoint set to '#{endpoint}'." if logger
+      logger.info "ObjectStorageClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/regions.rb
+++ b/lib/oci/regions.rb
@@ -1,5 +1,7 @@
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
+require 'pp'
+
 module OCI
   # Module defining available regions and helper methods to get value service endpoints
   module Regions
@@ -8,7 +10,12 @@ module OCI
       REGION_US_PHOENIX_1 = 'us-phoenix-1'.freeze,
       REGION_US_ASHBURN_1 = 'us-ashburn-1'.freeze,
       REGION_EU_FRANKFURT_1 = 'eu-frankfurt-1'.freeze,
-      REGION_UK_LONDON_1 = 'uk-london-1'.freeze
+      REGION_UK_LONDON_1 = 'uk-london-1'.freeze,
+      REGION_US_LANGLEY_1 = 'us-langley-1'.freeze,
+      REGION_US_LUKE_1 = 'us-luke-1'.freeze,
+      REGION_US_GOV_ASHBURN_1 = 'us-gov-ashburn-1'.freeze,
+      REGION_US_GOV_PHOENIX_1 = 'us-gov-phoenix-1'.freeze,
+      REGION_US_GOV_CHICAGO_1 = 'us-gov-chicago-1'.freeze
     ].freeze
 
     REGION_SHORT_NAMES_TO_LONG_NAMES = {
@@ -25,13 +32,20 @@ module OCI
       'us-phoenix-1': 'oc1'.freeze,
       'us-ashburn-1': 'oc1'.freeze,
       'eu-frankfurt-1': 'oc1'.freeze,
-      'uk-london-1': 'oc1'.freeze
+      'uk-london-1': 'oc1'.freeze,
+      'us-langley-1': 'oc2'.freeze,
+      'us-luke-1': 'oc2'.freeze,
+      'us-gov-ashburn-1': 'oc3'.freeze,
+      'us-gov-phoenix-1': 'oc3'.freeze,
+      'us-gov-chicago-1': 'oc3'.freeze
     }.freeze
     # ---  end of region realm mapping  ---
 
     # --- Start of realm domain mapping ---
     REALM_DOMAIN_MAPPING = {
-      'oc1': 'oraclecloud.com'.freeze
+      'oc1': 'oraclecloud.com'.freeze,
+      'oc2': 'oraclegovcloud.com'.freeze,
+      'oc3': 'oraclegovcloud.com'.freeze
     }.freeze
     # ---  end of realm domain mapping  ---
 
@@ -54,6 +68,8 @@ module OCI
       LoadBalancerClient: 'iaas',
       ObjectStorageClient: 'objectstorage',
       ResourceSearchClient: 'query',
+      StreamAdminClient: 'streams',
+      StreamClient: 'streams',
       VirtualNetworkClient: 'iaas',
       WaasClient: 'waas'
     }.freeze
@@ -120,9 +136,9 @@ module OCI
 
       # return second level domain if exists
       symbolised_realm = realm.to_sym
+
       return REALM_DOMAIN_MAPPING[symbolised_realm] if REALM_DOMAIN_MAPPING.key?(symbolised_realm)
 
-      # otherwise return oc1 domain by default
       REALM_DOMAIN_MAPPING[:oc1]
     end
   end

--- a/lib/oci/resource_search/resource_search_client.rb
+++ b/lib/oci/resource_search/resource_search_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new ResourceSearchClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20180409'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "ResourceSearchClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :ResourceSearchClient) + '/20180409'
-      logger.info "ResourceSearchClient endpoint set to '#{endpoint}'." if logger
+      logger.info "ResourceSearchClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/lib/oci/streaming/models/create_cursor_details.rb
+++ b/lib/oci/streaming/models/create_cursor_details.rb
@@ -4,44 +4,48 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
+  # Object used to create a cursor to consume messages in a stream.
+  class Streaming::Models::CreateCursorDetails # rubocop:disable Metrics/LineLength
+    TYPE_ENUM = [
+      TYPE_AFTER_OFFSET = 'AFTER_OFFSET'.freeze,
+      TYPE_AT_OFFSET = 'AT_OFFSET'.freeze,
+      TYPE_AT_TIME = 'AT_TIME'.freeze,
+      TYPE_LATEST = 'LATEST'.freeze,
+      TYPE_TRIM_HORIZON = 'TRIM_HORIZON'.freeze
+    ].freeze
+
+    # **[Required]** The partition to get messages from.
     # @return [String]
-    attr_accessor :compartment_id
+    attr_accessor :partition
 
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+    # **[Required]** The type of cursor, which determines the starting point from which the stream will be consumed:
     #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
+    # - `AFTER_OFFSET:` The partition position immediately following the offset you specify. (Offsets are assigned when you successfully append a message to a partition in a stream.)
+    # - `AT_OFFSET:` The exact partition position indicated by the offset you specify.
+    # - `AT_TIME:` A specific point in time.
+    # - `LATEST:` The most recent message in the partition that was added after the cursor was created.
+    # - `TRIM_HORIZON:` The oldest message in the partition that is within the retention period window.
     #
     # @return [String]
-    attr_accessor :display_name
+    attr_reader :type
 
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
+    # The offset to consume from if the cursor type is `AT_OFFSET` or `AFTER_OFFSET`.
+    # @return [Integer]
+    attr_accessor :offset
+
+    # The time to consume from if the cursor type is `AT_TIME`, expressed in [RFC 3339](https://tools.ietf.org/rfc/rfc3339) timestamp format.
     #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # @return [DateTime]
+    attr_accessor :time
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'partition': :'partition',
+        'type': :'type',
+        'offset': :'offset',
+        'time': :'time'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +54,10 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'partition': :'String',
+        'type': :'String',
+        'offset': :'Integer',
+        'time': :'DateTime'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,49 +68,36 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [String] :partition The value to assign to the {#partition} property
+    # @option attributes [String] :type The value to assign to the {#type} property
+    # @option attributes [Integer] :offset The value to assign to the {#offset} property
+    # @option attributes [DateTime] :time The value to assign to the {#time} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+      self.partition = attributes[:'partition'] if attributes[:'partition']
 
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
+      self.type = attributes[:'type'] if attributes[:'type']
 
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
+      self.offset = attributes[:'offset'] if attributes[:'offset']
 
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
-
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
-
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
-
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.time = attributes[:'time'] if attributes[:'time']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
+
+    # Custom attribute writer method checking allowed values (enum).
+    # @param [Object] type Object to be assigned
+    def type=(type)
+      # rubocop: disable Metrics/LineLength
+      raise "Invalid value for 'type': this must be one of the values in TYPE_ENUM." if type && !TYPE_ENUM.include?(type)
+
+      # rubocop: enable Metrics/LineLength
+      @type = type
+    end
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -118,11 +108,10 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        partition == other.partition &&
+        type == other.type &&
+        offset == other.offset &&
+        time == other.time
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +127,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [partition, type, offset, time].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/create_group_cursor_details.rb
+++ b/lib/oci/streaming/models/create_group_cursor_details.rb
@@ -4,49 +4,50 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateVaultDetails model.
-  class KeyManagement::Models::CreateVaultDetails # rubocop:disable Metrics/LineLength
-    VAULT_TYPE_ENUM = [
-      VAULT_TYPE_VIRTUAL_PRIVATE = 'VIRTUAL_PRIVATE'.freeze
+  # Object used to create a group cursor.
+  class Streaming::Models::CreateGroupCursorDetails # rubocop:disable Metrics/LineLength
+    TYPE_ENUM = [
+      TYPE_AT_TIME = 'AT_TIME'.freeze,
+      TYPE_LATEST = 'LATEST'.freeze,
+      TYPE_TRIM_HORIZON = 'TRIM_HORIZON'.freeze
     ].freeze
 
-    # **[Required]** The OCID of the compartment where you want to create this vault.
+    # **[Required]** The type of the cursor. This value is only used when the group is created.
     # @return [String]
-    attr_accessor :compartment_id
+    attr_reader :type
 
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
-    #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
+    # The time to consume from if type is AT_TIME.
+    # @return [DateTime]
+    attr_accessor :time
 
-    # **[Required]** A user-friendly name for the vault. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
+    # **[Required]** Name of the consumer group.
     # @return [String]
-    attr_accessor :display_name
+    attr_accessor :group_name
 
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # **[Required]** The type of vault to create. Each type of vault stores the key with different degrees of isolation and has different options and pricing.
-    #
+    # A unique identifier for the instance joining the consumer group. If an instanceName is not provided, a UUID will be generated and used.
     # @return [String]
-    attr_reader :vault_type
+    attr_accessor :instance_name
+
+    # The amount of a consumer instance inactivity time, before partition reservations are released.
+    # @return [Integer]
+    attr_accessor :timeout_in_ms
+
+    # When using consumer-groups, the default commit-on-get behaviour can be overriden by setting this value to false.
+    # If disabled, a consumer must manually commit their cursors.
+    #
+    # @return [BOOLEAN]
+    attr_accessor :commit_on_get
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'vault_type': :'vaultType'
+        'type': :'type',
+        'time': :'time',
+        'group_name': :'groupName',
+        'instance_name': :'instanceName',
+        'timeout_in_ms': :'timeoutInMs',
+        'commit_on_get': :'commitOnGet'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -55,11 +56,12 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'vault_type': :'String'
+        'type': :'String',
+        'time': :'DateTime',
+        'group_name': :'String',
+        'instance_name': :'String',
+        'timeout_in_ms': :'Integer',
+        'commit_on_get': :'BOOLEAN'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -70,58 +72,61 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [String] :vault_type The value to assign to the {#vault_type} property
+    # @option attributes [String] :type The value to assign to the {#type} property
+    # @option attributes [DateTime] :time The value to assign to the {#time} property
+    # @option attributes [String] :group_name The value to assign to the {#group_name} property
+    # @option attributes [String] :instance_name The value to assign to the {#instance_name} property
+    # @option attributes [Integer] :timeout_in_ms The value to assign to the {#timeout_in_ms} property
+    # @option attributes [BOOLEAN] :commit_on_get The value to assign to the {#commit_on_get} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+      self.type = attributes[:'type'] if attributes[:'type']
 
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
+      self.time = attributes[:'time'] if attributes[:'time']
 
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
+      self.group_name = attributes[:'groupName'] if attributes[:'groupName']
 
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+      raise 'You cannot provide both :groupName and :group_name' if attributes.key?(:'groupName') && attributes.key?(:'group_name')
 
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+      self.group_name = attributes[:'group_name'] if attributes[:'group_name']
 
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
+      self.instance_name = attributes[:'instanceName'] if attributes[:'instanceName']
 
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
+      raise 'You cannot provide both :instanceName and :instance_name' if attributes.key?(:'instanceName') && attributes.key?(:'instance_name')
 
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
+      self.instance_name = attributes[:'instance_name'] if attributes[:'instance_name']
 
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
+      self.timeout_in_ms = attributes[:'timeoutInMs'] if attributes[:'timeoutInMs']
+      self.timeout_in_ms = 30000 if timeout_in_ms.nil? && !attributes.key?(:'timeoutInMs') # rubocop:disable Style/StringLiterals
 
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
+      raise 'You cannot provide both :timeoutInMs and :timeout_in_ms' if attributes.key?(:'timeoutInMs') && attributes.key?(:'timeout_in_ms')
 
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
+      self.timeout_in_ms = attributes[:'timeout_in_ms'] if attributes[:'timeout_in_ms']
+      self.timeout_in_ms = 30000 if timeout_in_ms.nil? && !attributes.key?(:'timeoutInMs') && !attributes.key?(:'timeout_in_ms') # rubocop:disable Style/StringLiterals
 
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
+      self.commit_on_get = attributes[:'commitOnGet'] unless attributes[:'commitOnGet'].nil?
+      self.commit_on_get = true if commit_on_get.nil? && !attributes.key?(:'commitOnGet') # rubocop:disable Style/StringLiterals
 
-      self.vault_type = attributes[:'vaultType'] if attributes[:'vaultType']
+      raise 'You cannot provide both :commitOnGet and :commit_on_get' if attributes.key?(:'commitOnGet') && attributes.key?(:'commit_on_get')
 
-      raise 'You cannot provide both :vaultType and :vault_type' if attributes.key?(:'vaultType') && attributes.key?(:'vault_type')
-
-      self.vault_type = attributes[:'vault_type'] if attributes[:'vault_type']
+      self.commit_on_get = attributes[:'commit_on_get'] unless attributes[:'commit_on_get'].nil?
+      self.commit_on_get = true if commit_on_get.nil? && !attributes.key?(:'commitOnGet') && !attributes.key?(:'commit_on_get') # rubocop:disable Style/StringLiterals
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
 
     # Custom attribute writer method checking allowed values (enum).
-    # @param [Object] vault_type Object to be assigned
-    def vault_type=(vault_type)
+    # @param [Object] type Object to be assigned
+    def type=(type)
       # rubocop: disable Metrics/LineLength
-      raise "Invalid value for 'vault_type': this must be one of the values in VAULT_TYPE_ENUM." if vault_type && !VAULT_TYPE_ENUM.include?(vault_type)
+      raise "Invalid value for 'type': this must be one of the values in TYPE_ENUM." if type && !TYPE_ENUM.include?(type)
 
       # rubocop: enable Metrics/LineLength
-      @vault_type = vault_type
+      @type = type
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
@@ -133,11 +138,12 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        vault_type == other.vault_type
+        type == other.type &&
+        time == other.time &&
+        group_name == other.group_name &&
+        instance_name == other.instance_name &&
+        timeout_in_ms == other.timeout_in_ms &&
+        commit_on_get == other.commit_on_get
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -153,7 +159,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, vault_type].hash
+      [type, time, group_name, instance_name, timeout_in_ms, commit_on_get].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/create_stream_details.rb
+++ b/lib/oci/streaming/models/create_stream_details.rb
@@ -4,44 +4,54 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
+  # Object used to create a stream.
+  class Streaming::Models::CreateStreamDetails # rubocop:disable Metrics/LineLength
+    # **[Required]** The name of the stream. Avoid entering confidential information.
+    #
+    # Example: `TelemetryEvents`
+    #
+    # @return [String]
+    attr_accessor :name
+
+    # **[Required]** The number of partitions in the stream.
+    # @return [Integer]
+    attr_accessor :partitions
+
+    # **[Required]** The OCID of the compartment that contains the stream.
     # @return [String]
     attr_accessor :compartment_id
 
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+    # The retention period of the stream, in hours. Accepted values are between 24 and 168 (7 days).
+    # If not specified, the stream will have a retention period of 24 hours.
     #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
+    # @return [Integer]
+    attr_accessor :retention_in_hours
 
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
+    # Free-form tags for this resource. Each tag is a simple key-value pair that is applied with no predefined name, type, or namespace. Exists for cross-compatibility only.
+    # For more information, see [Resource Tags](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm).
     #
-    # @return [String]
-    attr_accessor :display_name
-
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
+    # Example: `{\"Department\": \"Finance\"}`
     #
     # @return [Hash<String, String>]
     attr_accessor :freeform_tags
 
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm).
+    #
+    # Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+    #
+    # @return [Hash<String, Hash<String, Object>>]
+    attr_accessor :defined_tags
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
+        'name': :'name',
+        'partitions': :'partitions',
         'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
+        'retention_in_hours': :'retentionInHours',
         'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'defined_tags': :'definedTags'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +60,12 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
+        'name': :'String',
+        'partitions': :'Integer',
         'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
+        'retention_in_hours': :'Integer',
         'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'defined_tags': :'Hash<String, Hash<String, Object>>'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,16 +76,21 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
+    # @option attributes [String] :name The value to assign to the {#name} property
+    # @option attributes [Integer] :partitions The value to assign to the {#partitions} property
     # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
+    # @option attributes [Integer] :retention_in_hours The value to assign to the {#retention_in_hours} property
     # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+
+      self.name = attributes[:'name'] if attributes[:'name']
+
+      self.partitions = attributes[:'partitions'] if attributes[:'partitions']
 
       self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
 
@@ -82,17 +98,11 @@ module OCI
 
       self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
 
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+      self.retention_in_hours = attributes[:'retentionInHours'] if attributes[:'retentionInHours']
 
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+      raise 'You cannot provide both :retentionInHours and :retention_in_hours' if attributes.key?(:'retentionInHours') && attributes.key?(:'retention_in_hours')
 
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
+      self.retention_in_hours = attributes[:'retention_in_hours'] if attributes[:'retention_in_hours']
 
       self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
 
@@ -100,11 +110,11 @@ module OCI
 
       self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
 
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
+      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
 
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
+      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
 
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +128,12 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
+        name == other.name &&
+        partitions == other.partitions &&
         compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
+        retention_in_hours == other.retention_in_hours &&
         freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        defined_tags == other.defined_tags
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +149,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [name, partitions, compartment_id, retention_in_hours, freeform_tags, defined_tags].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/cursor.rb
+++ b/lib/oci/streaming/models/cursor.rb
@@ -4,44 +4,18 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
+  # A cursor that indicates the position in the stream from which you want to begin consuming messages and which is required by the {#get_messages get_messages} operation.
+  #
+  class Streaming::Models::Cursor # rubocop:disable Metrics/LineLength
+    # **[Required]** The cursor to pass to the `GetMessages` operation.
     # @return [String]
-    attr_accessor :compartment_id
-
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
-    #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
-    # @return [String]
-    attr_accessor :display_name
-
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    attr_accessor :value
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'value': :'value'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +24,7 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'value': :'String'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,46 +35,14 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [String] :value The value to assign to the {#value} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
-
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
-
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
-
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
-
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
-
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
-
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.value = attributes[:'value'] if attributes[:'value']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +56,7 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        value == other.value
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +72,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [value].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/group.rb
+++ b/lib/oci/streaming/models/group.rb
@@ -1,47 +1,32 @@
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
 require 'date'
+require 'logger'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
+  # Represents the current state of a consumer group, including partition reservations and committed offsets.
+  #
+  class Streaming::Models::Group # rubocop:disable Metrics/LineLength
+    # The streamId for which the group exists.
     # @return [String]
-    attr_accessor :compartment_id
+    attr_accessor :stream_id
 
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
-    #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
+    # The name of the consumer group.
     # @return [String]
-    attr_accessor :display_name
+    attr_accessor :group_name
 
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # An array of the partition reservations of a group.
+    # @return [Array<OCI::Streaming::Models::PartitionReservation>]
+    attr_accessor :reservations
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'stream_id': :'streamId',
+        'group_name': :'groupName',
+        'reservations': :'reservations'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +35,9 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'stream_id': :'String',
+        'group_name': :'String',
+        'reservations': :'Array<OCI::Streaming::Models::PartitionReservation>'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,46 +48,28 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [String] :stream_id The value to assign to the {#stream_id} property
+    # @option attributes [String] :group_name The value to assign to the {#group_name} property
+    # @option attributes [Array<OCI::Streaming::Models::PartitionReservation>] :reservations The value to assign to the {#reservations} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+      self.stream_id = attributes[:'streamId'] if attributes[:'streamId']
 
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
+      raise 'You cannot provide both :streamId and :stream_id' if attributes.key?(:'streamId') && attributes.key?(:'stream_id')
 
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
+      self.stream_id = attributes[:'stream_id'] if attributes[:'stream_id']
 
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+      self.group_name = attributes[:'groupName'] if attributes[:'groupName']
 
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+      raise 'You cannot provide both :groupName and :group_name' if attributes.key?(:'groupName') && attributes.key?(:'group_name')
 
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
+      self.group_name = attributes[:'group_name'] if attributes[:'group_name']
 
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
-
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.reservations = attributes[:'reservations'] if attributes[:'reservations']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +83,9 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        stream_id == other.stream_id &&
+        group_name == other.group_name &&
+        reservations == other.reservations
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +101,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [stream_id, group_name, reservations].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/message.rb
+++ b/lib/oci/streaming/models/message.rb
@@ -4,44 +4,42 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
+  # A message in a stream.
+  class Streaming::Models::Message # rubocop:disable Metrics/LineLength
+    # **[Required]** The name of the stream that the message belongs to.
     # @return [String]
-    attr_accessor :compartment_id
+    attr_accessor :stream
 
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
-    #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
+    # **[Required]** The ID of the partition where the message is stored.
     # @return [String]
-    attr_accessor :display_name
+    attr_accessor :partition
 
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
+    # **[Required]** The key associated with the message, expressed as a byte array.
+    # @return [String]
+    attr_accessor :key
 
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # **[Required]** The value associated with the message, expressed as a byte array.
+    # @return [String]
+    attr_accessor :value
+
+    # **[Required]** The offset of the message, which uniquely identifies it within the partition.
+    # @return [Integer]
+    attr_accessor :offset
+
+    # **[Required]** The timestamp indicating when the server appended the message to the stream.
+    # @return [DateTime]
+    attr_accessor :timestamp
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'stream': :'stream',
+        'partition': :'partition',
+        'key': :'key',
+        'value': :'value',
+        'offset': :'offset',
+        'timestamp': :'timestamp'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +48,12 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'stream': :'String',
+        'partition': :'String',
+        'key': :'String',
+        'value': :'String',
+        'offset': :'Integer',
+        'timestamp': :'DateTime'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,46 +64,29 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [String] :stream The value to assign to the {#stream} property
+    # @option attributes [String] :partition The value to assign to the {#partition} property
+    # @option attributes [String] :key The value to assign to the {#key} property
+    # @option attributes [String] :value The value to assign to the {#value} property
+    # @option attributes [Integer] :offset The value to assign to the {#offset} property
+    # @option attributes [DateTime] :timestamp The value to assign to the {#timestamp} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+      self.stream = attributes[:'stream'] if attributes[:'stream']
 
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
+      self.partition = attributes[:'partition'] if attributes[:'partition']
 
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
+      self.key = attributes[:'key'] if attributes[:'key']
 
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+      self.value = attributes[:'value'] if attributes[:'value']
 
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+      self.offset = attributes[:'offset'] if attributes[:'offset']
 
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
-
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.timestamp = attributes[:'timestamp'] if attributes[:'timestamp']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +100,12 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        stream == other.stream &&
+        partition == other.partition &&
+        key == other.key &&
+        value == other.value &&
+        offset == other.offset &&
+        timestamp == other.timestamp
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +121,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [stream, partition, key, value, offset, timestamp].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/partition_reservation.rb
+++ b/lib/oci/streaming/models/partition_reservation.rb
@@ -4,44 +4,33 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
+  # Represents the state of a single partition reservation.
+  #
+  class Streaming::Models::PartitionReservation # rubocop:disable Metrics/LineLength
+    # The partition for which the reservation applies.
     # @return [String]
-    attr_accessor :compartment_id
+    attr_accessor :partition
 
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
-    #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
+    # The latest offset which has been committed for this partition.
+    # @return [Integer]
+    attr_accessor :committed_offset
 
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
+    # The consumer instance which currently has the partition reserved.
     # @return [String]
-    attr_accessor :display_name
+    attr_accessor :reserved_instance
 
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # A timestamp when the current reservation expires.
+    # @return [DateTime]
+    attr_accessor :time_reserved_until
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'partition': :'partition',
+        'committed_offset': :'committedOffset',
+        'reserved_instance': :'reservedInstance',
+        'time_reserved_until': :'timeReservedUntil'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +39,10 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'partition': :'String',
+        'committed_offset': :'Integer',
+        'reserved_instance': :'String',
+        'time_reserved_until': :'DateTime'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,46 +53,35 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [String] :partition The value to assign to the {#partition} property
+    # @option attributes [Integer] :committed_offset The value to assign to the {#committed_offset} property
+    # @option attributes [String] :reserved_instance The value to assign to the {#reserved_instance} property
+    # @option attributes [DateTime] :time_reserved_until The value to assign to the {#time_reserved_until} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+      self.partition = attributes[:'partition'] if attributes[:'partition']
 
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
+      self.committed_offset = attributes[:'committedOffset'] if attributes[:'committedOffset']
 
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
+      raise 'You cannot provide both :committedOffset and :committed_offset' if attributes.key?(:'committedOffset') && attributes.key?(:'committed_offset')
 
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+      self.committed_offset = attributes[:'committed_offset'] if attributes[:'committed_offset']
 
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+      self.reserved_instance = attributes[:'reservedInstance'] if attributes[:'reservedInstance']
 
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
+      raise 'You cannot provide both :reservedInstance and :reserved_instance' if attributes.key?(:'reservedInstance') && attributes.key?(:'reserved_instance')
 
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
+      self.reserved_instance = attributes[:'reserved_instance'] if attributes[:'reserved_instance']
 
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
+      self.time_reserved_until = attributes[:'timeReservedUntil'] if attributes[:'timeReservedUntil']
 
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
+      raise 'You cannot provide both :timeReservedUntil and :time_reserved_until' if attributes.key?(:'timeReservedUntil') && attributes.key?(:'time_reserved_until')
 
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.time_reserved_until = attributes[:'time_reserved_until'] if attributes[:'time_reserved_until']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +95,10 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        partition == other.partition &&
+        committed_offset == other.committed_offset &&
+        reserved_instance == other.reserved_instance &&
+        time_reserved_until == other.time_reserved_until
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +114,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [partition, committed_offset, reserved_instance, time_reserved_until].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/put_messages_details.rb
+++ b/lib/oci/streaming/models/put_messages_details.rb
@@ -4,44 +4,17 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
-    # @return [String]
-    attr_accessor :compartment_id
-
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
-    #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
-    # @return [String]
-    attr_accessor :display_name
-
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+  # Object that represents an array of messages to emit to a stream.
+  class Streaming::Models::PutMessagesDetails # rubocop:disable Metrics/LineLength
+    # **[Required]** The array of messages to put into a stream.
+    # @return [Array<OCI::Streaming::Models::PutMessagesDetailsEntry>]
+    attr_accessor :messages
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'messages': :'messages'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +23,7 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'messages': :'Array<OCI::Streaming::Models::PutMessagesDetailsEntry>'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,46 +34,14 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [Array<OCI::Streaming::Models::PutMessagesDetailsEntry>] :messages The value to assign to the {#messages} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
-
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
-
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
-
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
-
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
-
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
-
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.messages = attributes[:'messages'] if attributes[:'messages']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +55,7 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        messages == other.messages
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +71,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [messages].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/put_messages_details_entry.rb
+++ b/lib/oci/streaming/models/put_messages_details_entry.rb
@@ -4,44 +4,23 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
-    # @return [String]
-    attr_accessor :compartment_id
-
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
-    #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
+  # Object that represents a message to emit to a stream.
+  class Streaming::Models::PutMessagesDetailsEntry # rubocop:disable Metrics/LineLength
+    # The key of the message, expressed as a byte array up to 256 bytes in size. Messages with the same key are stored in the same partition.
     #
     # @return [String]
-    attr_accessor :display_name
+    attr_accessor :key
 
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # **[Required]** The message, expressed as a byte array up to 1 MiB in size.
+    # @return [String]
+    attr_accessor :value
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'key': :'key',
+        'value': :'value'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +29,8 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'key': :'String',
+        'value': :'String'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,46 +41,17 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [String] :key The value to assign to the {#key} property
+    # @option attributes [String] :value The value to assign to the {#value} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+      self.key = attributes[:'key'] if attributes[:'key']
 
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
-
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
-
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
-
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
-
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
-
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.value = attributes[:'value'] if attributes[:'value']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +65,8 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        key == other.key &&
+        value == other.value
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +82,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [key, value].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/put_messages_result.rb
+++ b/lib/oci/streaming/models/put_messages_result.rb
@@ -4,44 +4,28 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
-    # @return [String]
-    attr_accessor :compartment_id
+  # The response to a {#put_messages put_messages} request. It indicates the number
+  # of failed messages as well as an array of results for successful and failed messages.
+  #
+  class Streaming::Models::PutMessagesResult # rubocop:disable Metrics/LineLength
+    # **[Required]** The number of messages that failed to be added to the stream.
+    # @return [Integer]
+    attr_accessor :failures
 
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+    # An array of items representing the result of each message.
+    # The order is guaranteed to be the same as in the `PutMessagesDetails` object.
+    # If a message was successfully appended to the stream, the entry includes the `offset`, `partition`, and `timestamp`.
+    # If a message failed to be appended to the stream, the entry includes the `error` and `errorMessage`.
     #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
-    # @return [String]
-    attr_accessor :display_name
-
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # @return [Array<OCI::Streaming::Models::PutMessagesResultEntry>]
+    attr_accessor :entries
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'failures': :'failures',
+        'entries': :'entries'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +34,8 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'failures': :'Integer',
+        'entries': :'Array<OCI::Streaming::Models::PutMessagesResultEntry>'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,46 +46,17 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [Integer] :failures The value to assign to the {#failures} property
+    # @option attributes [Array<OCI::Streaming::Models::PutMessagesResultEntry>] :entries The value to assign to the {#entries} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+      self.failures = attributes[:'failures'] if attributes[:'failures']
 
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
-
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
-
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
-
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
-
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
-
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.entries = attributes[:'entries'] if attributes[:'entries']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +70,8 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        failures == other.failures &&
+        entries == other.entries
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +87,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [failures, entries].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/put_messages_result_entry.rb
+++ b/lib/oci/streaming/models/put_messages_result_entry.rb
@@ -4,22 +4,40 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # Information represents a notification follow-up
-  class AnnouncementsService::Models::NotificationFollowupDetails # rubocop:disable Metrics/LineLength
-    # The follow-up message, a markdown format input
+  # Represents the result of a {#put_messages put_messages} request, whether it was successful or not.
+  # If a message was successfully appended to the stream, the entry includes the `offset`, `partition`, and `timestamp`.
+  # If the message failed to be appended to the stream, the entry includes the `error` and `errorMessage`.
+  #
+  class Streaming::Models::PutMessagesResultEntry # rubocop:disable Metrics/LineLength
+    # The ID of the partition where the message was stored.
     # @return [String]
-    attr_accessor :message
+    attr_accessor :partition
 
-    # When the update is made
+    # The offset of the message in the partition.
+    # @return [Integer]
+    attr_accessor :offset
+
+    # The timestamp indicating when the server appended the message to the stream.
     # @return [DateTime]
-    attr_accessor :time_created
+    attr_accessor :timestamp
+
+    # The error code, in case the message was not successfully appended to the stream.
+    # @return [String]
+    attr_accessor :error
+
+    # A human-readable error message associated with the error code.
+    # @return [String]
+    attr_accessor :error_message
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'message': :'message',
-        'time_created': :'timeCreated'
+        'partition': :'partition',
+        'offset': :'offset',
+        'timestamp': :'timestamp',
+        'error': :'error',
+        'error_message': :'errorMessage'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -28,8 +46,11 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'message': :'String',
-        'time_created': :'DateTime'
+        'partition': :'String',
+        'offset': :'Integer',
+        'timestamp': :'DateTime',
+        'error': :'String',
+        'error_message': :'String'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -40,21 +61,30 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :message The value to assign to the {#message} property
-    # @option attributes [DateTime] :time_created The value to assign to the {#time_created} property
+    # @option attributes [String] :partition The value to assign to the {#partition} property
+    # @option attributes [Integer] :offset The value to assign to the {#offset} property
+    # @option attributes [DateTime] :timestamp The value to assign to the {#timestamp} property
+    # @option attributes [String] :error The value to assign to the {#error} property
+    # @option attributes [String] :error_message The value to assign to the {#error_message} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.message = attributes[:'message'] if attributes[:'message']
+      self.partition = attributes[:'partition'] if attributes[:'partition']
 
-      self.time_created = attributes[:'timeCreated'] if attributes[:'timeCreated']
+      self.offset = attributes[:'offset'] if attributes[:'offset']
 
-      raise 'You cannot provide both :timeCreated and :time_created' if attributes.key?(:'timeCreated') && attributes.key?(:'time_created')
+      self.timestamp = attributes[:'timestamp'] if attributes[:'timestamp']
 
-      self.time_created = attributes[:'time_created'] if attributes[:'time_created']
+      self.error = attributes[:'error'] if attributes[:'error']
+
+      self.error_message = attributes[:'errorMessage'] if attributes[:'errorMessage']
+
+      raise 'You cannot provide both :errorMessage and :error_message' if attributes.key?(:'errorMessage') && attributes.key?(:'error_message')
+
+      self.error_message = attributes[:'error_message'] if attributes[:'error_message']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -68,8 +98,11 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        message == other.message &&
-        time_created == other.time_created
+        partition == other.partition &&
+        offset == other.offset &&
+        timestamp == other.timestamp &&
+        error == other.error &&
+        error_message == other.error_message
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -85,7 +118,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [message, time_created].hash
+      [partition, offset, timestamp, error, error_message].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/stream.rb
+++ b/lib/oci/streaming/models/stream.rb
@@ -1,0 +1,319 @@
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+require 'date'
+require 'logger'
+
+# rubocop:disable Lint/UnneededCopDisableDirective
+module OCI
+  # Detailed representation of a stream, including all its partitions.
+  class Streaming::Models::Stream # rubocop:disable Metrics/LineLength
+    LIFECYCLE_STATE_ENUM = [
+      LIFECYCLE_STATE_CREATING = 'CREATING'.freeze,
+      LIFECYCLE_STATE_ACTIVE = 'ACTIVE'.freeze,
+      LIFECYCLE_STATE_DELETING = 'DELETING'.freeze,
+      LIFECYCLE_STATE_DELETED = 'DELETED'.freeze,
+      LIFECYCLE_STATE_FAILED = 'FAILED'.freeze,
+      LIFECYCLE_STATE_UNKNOWN_ENUM_VALUE = 'UNKNOWN_ENUM_VALUE'.freeze
+    ].freeze
+
+    # **[Required]** The name of the stream. Avoid entering confidential information.
+    #
+    # Example: `TelemetryEvents`
+    #
+    # @return [String]
+    attr_accessor :name
+
+    # **[Required]** The OCID of the stream.
+    # @return [String]
+    attr_accessor :id
+
+    # **[Required]** The number of partitions in the stream.
+    # @return [Integer]
+    attr_accessor :partitions
+
+    # **[Required]** The retention period of the stream, in hours. This property is read-only.
+    # @return [Integer]
+    attr_accessor :retention_in_hours
+
+    # **[Required]** The OCID of the stream.
+    # @return [String]
+    attr_accessor :compartment_id
+
+    # **[Required]** The current state of the stream.
+    # @return [String]
+    attr_reader :lifecycle_state
+
+    # Any additional details about the current state of the stream.
+    # @return [String]
+    attr_accessor :lifecycle_state_details
+
+    # **[Required]** The date and time the stream was created, expressed in in [RFC 3339](https://tools.ietf.org/rfc/rfc3339) timestamp format.
+    #
+    # Example: `2018-04-20T00:00:07.405Z`
+    #
+    # @return [DateTime]
+    attr_accessor :time_created
+
+    # **[Required]** The endpoint to use when creating the StreamClient to consume or publish messages in the stream.
+    # @return [String]
+    attr_accessor :messages_endpoint
+
+    # Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. Exists for cross-compatibility only.
+    # For more information, see [Resource Tags](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm).
+    #
+    # Example: `{\"Department\": \"Finance\"}`
+    #
+    # @return [Hash<String, String>]
+    attr_accessor :freeform_tags
+
+    # Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm).
+    #
+    # Example: `{\"Operations\": {\"CostCenter\": \"42\"}}'
+    #
+    # @return [Hash<String, Hash<String, Object>>]
+    attr_accessor :defined_tags
+
+    # Attribute mapping from ruby-style variable name to JSON key.
+    def self.attribute_map
+      {
+        # rubocop:disable Style/SymbolLiteral
+        'name': :'name',
+        'id': :'id',
+        'partitions': :'partitions',
+        'retention_in_hours': :'retentionInHours',
+        'compartment_id': :'compartmentId',
+        'lifecycle_state': :'lifecycleState',
+        'lifecycle_state_details': :'lifecycleStateDetails',
+        'time_created': :'timeCreated',
+        'messages_endpoint': :'messagesEndpoint',
+        'freeform_tags': :'freeformTags',
+        'defined_tags': :'definedTags'
+        # rubocop:enable Style/SymbolLiteral
+      }
+    end
+
+    # Attribute type mapping.
+    def self.swagger_types
+      {
+        # rubocop:disable Style/SymbolLiteral
+        'name': :'String',
+        'id': :'String',
+        'partitions': :'Integer',
+        'retention_in_hours': :'Integer',
+        'compartment_id': :'String',
+        'lifecycle_state': :'String',
+        'lifecycle_state_details': :'String',
+        'time_created': :'DateTime',
+        'messages_endpoint': :'String',
+        'freeform_tags': :'Hash<String, String>',
+        'defined_tags': :'Hash<String, Hash<String, Object>>'
+        # rubocop:enable Style/SymbolLiteral
+      }
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
+
+
+    # Initializes the object
+    # @param [Hash] attributes Model attributes in the form of hash
+    # @option attributes [String] :name The value to assign to the {#name} property
+    # @option attributes [String] :id The value to assign to the {#id} property
+    # @option attributes [Integer] :partitions The value to assign to the {#partitions} property
+    # @option attributes [Integer] :retention_in_hours The value to assign to the {#retention_in_hours} property
+    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
+    # @option attributes [String] :lifecycle_state The value to assign to the {#lifecycle_state} property
+    # @option attributes [String] :lifecycle_state_details The value to assign to the {#lifecycle_state_details} property
+    # @option attributes [DateTime] :time_created The value to assign to the {#time_created} property
+    # @option attributes [String] :messages_endpoint The value to assign to the {#messages_endpoint} property
+    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
+    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
+    def initialize(attributes = {})
+      return unless attributes.is_a?(Hash)
+
+      # convert string to symbol for hash key
+      attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+
+      self.name = attributes[:'name'] if attributes[:'name']
+
+      self.id = attributes[:'id'] if attributes[:'id']
+
+      self.partitions = attributes[:'partitions'] if attributes[:'partitions']
+
+      self.retention_in_hours = attributes[:'retentionInHours'] if attributes[:'retentionInHours']
+
+      raise 'You cannot provide both :retentionInHours and :retention_in_hours' if attributes.key?(:'retentionInHours') && attributes.key?(:'retention_in_hours')
+
+      self.retention_in_hours = attributes[:'retention_in_hours'] if attributes[:'retention_in_hours']
+
+      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+
+      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
+
+      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
+
+      self.lifecycle_state = attributes[:'lifecycleState'] if attributes[:'lifecycleState']
+
+      raise 'You cannot provide both :lifecycleState and :lifecycle_state' if attributes.key?(:'lifecycleState') && attributes.key?(:'lifecycle_state')
+
+      self.lifecycle_state = attributes[:'lifecycle_state'] if attributes[:'lifecycle_state']
+
+      self.lifecycle_state_details = attributes[:'lifecycleStateDetails'] if attributes[:'lifecycleStateDetails']
+
+      raise 'You cannot provide both :lifecycleStateDetails and :lifecycle_state_details' if attributes.key?(:'lifecycleStateDetails') && attributes.key?(:'lifecycle_state_details')
+
+      self.lifecycle_state_details = attributes[:'lifecycle_state_details'] if attributes[:'lifecycle_state_details']
+
+      self.time_created = attributes[:'timeCreated'] if attributes[:'timeCreated']
+
+      raise 'You cannot provide both :timeCreated and :time_created' if attributes.key?(:'timeCreated') && attributes.key?(:'time_created')
+
+      self.time_created = attributes[:'time_created'] if attributes[:'time_created']
+
+      self.messages_endpoint = attributes[:'messagesEndpoint'] if attributes[:'messagesEndpoint']
+
+      raise 'You cannot provide both :messagesEndpoint and :messages_endpoint' if attributes.key?(:'messagesEndpoint') && attributes.key?(:'messages_endpoint')
+
+      self.messages_endpoint = attributes[:'messages_endpoint'] if attributes[:'messages_endpoint']
+
+      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
+
+      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
+
+      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
+
+      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+
+      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+
+      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
+
+    # Custom attribute writer method checking allowed values (enum).
+    # @param [Object] lifecycle_state Object to be assigned
+    def lifecycle_state=(lifecycle_state)
+      # rubocop:disable Style/ConditionalAssignment
+      if lifecycle_state && !LIFECYCLE_STATE_ENUM.include?(lifecycle_state)
+        # rubocop: disable Metrics/LineLength
+        OCI.logger.debug("Unknown value for 'lifecycle_state' [" + lifecycle_state + "]. Mapping to 'LIFECYCLE_STATE_UNKNOWN_ENUM_VALUE'") if OCI.logger
+        # rubocop: enable Metrics/LineLength
+        @lifecycle_state = LIFECYCLE_STATE_UNKNOWN_ENUM_VALUE
+      else
+        @lifecycle_state = lifecycle_state
+      end
+      # rubocop:enable Style/ConditionalAssignment
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
+
+
+    # Checks equality by comparing each attribute.
+    # @param [Object] other the other object to be compared
+    def ==(other)
+      return true if equal?(other)
+
+      self.class == other.class &&
+        name == other.name &&
+        id == other.id &&
+        partitions == other.partitions &&
+        retention_in_hours == other.retention_in_hours &&
+        compartment_id == other.compartment_id &&
+        lifecycle_state == other.lifecycle_state &&
+        lifecycle_state_details == other.lifecycle_state_details &&
+        time_created == other.time_created &&
+        messages_endpoint == other.messages_endpoint &&
+        freeform_tags == other.freeform_tags &&
+        defined_tags == other.defined_tags
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
+
+    # @see the `==` method
+    # @param [Object] other the other object to be compared
+    def eql?(other)
+      self == other
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
+
+
+    # Calculates hash code according to all attributes.
+    # @return [Fixnum] Hash code
+    def hash
+      [name, id, partitions, retention_in_hours, compartment_id, lifecycle_state, lifecycle_state_details, time_created, messages_endpoint, freeform_tags, defined_tags].hash
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
+
+    # rubocop:disable Metrics/AbcSize, Layout/EmptyLines
+
+
+    # Builds the object from hash
+    # @param [Hash] attributes Model attributes in the form of hash
+    # @return [Object] Returns the model itself
+    def build_from_hash(attributes)
+      return nil unless attributes.is_a?(Hash)
+
+      self.class.swagger_types.each_pair do |key, type|
+        if type =~ /^Array<(.*)>/i
+          # check to ensure the input is an array given that the the attribute
+          # is documented as an array but the input is not
+          if attributes[self.class.attribute_map[key]].is_a?(Array)
+            public_method("#{key}=").call(
+              attributes[self.class.attribute_map[key]]
+                .map { |v| OCI::Internal::Util.convert_to_type(Regexp.last_match(1), v) }
+            )
+          end
+        elsif !attributes[self.class.attribute_map[key]].nil?
+          public_method("#{key}=").call(
+            OCI::Internal::Util.convert_to_type(type, attributes[self.class.attribute_map[key]])
+          )
+        end
+        # or else data not found in attributes(hash), not an issue as the data can be optional
+      end
+
+      self
+    end
+    # rubocop:enable Metrics/AbcSize, Layout/EmptyLines
+
+    # Returns the string representation of the object
+    # @return [String] String presentation of the object
+    def to_s
+      to_hash.to_s
+    end
+
+    # Returns the object in the form of hash
+    # @return [Hash] Returns the object in the form of hash
+    def to_hash
+      hash = {}
+      self.class.attribute_map.each_pair do |attr, param|
+        value = public_method(attr).call
+        next if value.nil? && !instance_variable_defined?("@#{attr}")
+
+        hash[param] = _to_hash(value)
+      end
+      hash
+    end
+
+    private
+
+    # Outputs non-array value in the form of hash
+    # For object, use to_hash. Otherwise, just return the value
+    # @param [Object] value Any valid value
+    # @return [Hash] Returns the value in the form of hash
+    def _to_hash(value)
+      if value.is_a?(Array)
+        value.compact.map { |v| _to_hash(v) }
+      elsif value.is_a?(Hash)
+        {}.tap do |hash|
+          value.each { |k, v| hash[k] = _to_hash(v) }
+        end
+      elsif value.respond_to? :to_hash
+        value.to_hash
+      else
+        value
+      end
+    end
+  end
+end
+# rubocop:enable Lint/UnneededCopDisableDirective

--- a/lib/oci/streaming/models/stream_summary.rb
+++ b/lib/oci/streaming/models/stream_summary.rb
@@ -1,0 +1,291 @@
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+require 'date'
+require 'logger'
+
+# rubocop:disable Lint/UnneededCopDisableDirective
+module OCI
+  # Summary representation of a stream.
+  class Streaming::Models::StreamSummary # rubocop:disable Metrics/LineLength
+    LIFECYCLE_STATE_ENUM = [
+      LIFECYCLE_STATE_CREATING = 'CREATING'.freeze,
+      LIFECYCLE_STATE_ACTIVE = 'ACTIVE'.freeze,
+      LIFECYCLE_STATE_DELETING = 'DELETING'.freeze,
+      LIFECYCLE_STATE_DELETED = 'DELETED'.freeze,
+      LIFECYCLE_STATE_FAILED = 'FAILED'.freeze,
+      LIFECYCLE_STATE_UNKNOWN_ENUM_VALUE = 'UNKNOWN_ENUM_VALUE'.freeze
+    ].freeze
+
+    # **[Required]** The name of the stream.
+    #
+    # Example: `TelemetryEvents`
+    #
+    # @return [String]
+    attr_accessor :name
+
+    # **[Required]** The OCID of the stream.
+    # @return [String]
+    attr_accessor :id
+
+    # **[Required]** The number of partitions in the stream.
+    # @return [Integer]
+    attr_accessor :partitions
+
+    # **[Required]** The OCID of the compartment that contains the stream.
+    # @return [String]
+    attr_accessor :compartment_id
+
+    # **[Required]** The current state of the stream.
+    # @return [String]
+    attr_reader :lifecycle_state
+
+    # **[Required]** The date and time the stream was created, expressed in [RFC 3339](https://tools.ietf.org/rfc/rfc3339) timestamp format.
+    #
+    # Example: `2018-04-20T00:00:07.405Z`
+    #
+    # @return [DateTime]
+    attr_accessor :time_created
+
+    # **[Required]** The endpoint to use when creating the StreamClient to consume or publish messages in the stream.
+    # @return [String]
+    attr_accessor :messages_endpoint
+
+    # Free-form tags for this resource. Each tag is a simple key-value pair that is applied with no predefined name, type, or namespace. Exists for cross-compatibility only.
+    # For more information, see [Resource Tags](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm).
+    #
+    # Example: `{\"Department\": \"Finance\"}`
+    #
+    # @return [Hash<String, String>]
+    attr_accessor :freeform_tags
+
+    # Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm).
+    #
+    # Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+    #
+    # @return [Hash<String, Hash<String, Object>>]
+    attr_accessor :defined_tags
+
+    # Attribute mapping from ruby-style variable name to JSON key.
+    def self.attribute_map
+      {
+        # rubocop:disable Style/SymbolLiteral
+        'name': :'name',
+        'id': :'id',
+        'partitions': :'partitions',
+        'compartment_id': :'compartmentId',
+        'lifecycle_state': :'lifecycleState',
+        'time_created': :'timeCreated',
+        'messages_endpoint': :'messagesEndpoint',
+        'freeform_tags': :'freeformTags',
+        'defined_tags': :'definedTags'
+        # rubocop:enable Style/SymbolLiteral
+      }
+    end
+
+    # Attribute type mapping.
+    def self.swagger_types
+      {
+        # rubocop:disable Style/SymbolLiteral
+        'name': :'String',
+        'id': :'String',
+        'partitions': :'Integer',
+        'compartment_id': :'String',
+        'lifecycle_state': :'String',
+        'time_created': :'DateTime',
+        'messages_endpoint': :'String',
+        'freeform_tags': :'Hash<String, String>',
+        'defined_tags': :'Hash<String, Hash<String, Object>>'
+        # rubocop:enable Style/SymbolLiteral
+      }
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
+
+
+    # Initializes the object
+    # @param [Hash] attributes Model attributes in the form of hash
+    # @option attributes [String] :name The value to assign to the {#name} property
+    # @option attributes [String] :id The value to assign to the {#id} property
+    # @option attributes [Integer] :partitions The value to assign to the {#partitions} property
+    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
+    # @option attributes [String] :lifecycle_state The value to assign to the {#lifecycle_state} property
+    # @option attributes [DateTime] :time_created The value to assign to the {#time_created} property
+    # @option attributes [String] :messages_endpoint The value to assign to the {#messages_endpoint} property
+    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
+    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
+    def initialize(attributes = {})
+      return unless attributes.is_a?(Hash)
+
+      # convert string to symbol for hash key
+      attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+
+      self.name = attributes[:'name'] if attributes[:'name']
+
+      self.id = attributes[:'id'] if attributes[:'id']
+
+      self.partitions = attributes[:'partitions'] if attributes[:'partitions']
+
+      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+
+      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
+
+      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
+
+      self.lifecycle_state = attributes[:'lifecycleState'] if attributes[:'lifecycleState']
+
+      raise 'You cannot provide both :lifecycleState and :lifecycle_state' if attributes.key?(:'lifecycleState') && attributes.key?(:'lifecycle_state')
+
+      self.lifecycle_state = attributes[:'lifecycle_state'] if attributes[:'lifecycle_state']
+
+      self.time_created = attributes[:'timeCreated'] if attributes[:'timeCreated']
+
+      raise 'You cannot provide both :timeCreated and :time_created' if attributes.key?(:'timeCreated') && attributes.key?(:'time_created')
+
+      self.time_created = attributes[:'time_created'] if attributes[:'time_created']
+
+      self.messages_endpoint = attributes[:'messagesEndpoint'] if attributes[:'messagesEndpoint']
+
+      raise 'You cannot provide both :messagesEndpoint and :messages_endpoint' if attributes.key?(:'messagesEndpoint') && attributes.key?(:'messages_endpoint')
+
+      self.messages_endpoint = attributes[:'messages_endpoint'] if attributes[:'messages_endpoint']
+
+      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
+
+      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
+
+      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
+
+      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
+
+      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
+
+      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
+
+    # Custom attribute writer method checking allowed values (enum).
+    # @param [Object] lifecycle_state Object to be assigned
+    def lifecycle_state=(lifecycle_state)
+      # rubocop:disable Style/ConditionalAssignment
+      if lifecycle_state && !LIFECYCLE_STATE_ENUM.include?(lifecycle_state)
+        # rubocop: disable Metrics/LineLength
+        OCI.logger.debug("Unknown value for 'lifecycle_state' [" + lifecycle_state + "]. Mapping to 'LIFECYCLE_STATE_UNKNOWN_ENUM_VALUE'") if OCI.logger
+        # rubocop: enable Metrics/LineLength
+        @lifecycle_state = LIFECYCLE_STATE_UNKNOWN_ENUM_VALUE
+      else
+        @lifecycle_state = lifecycle_state
+      end
+      # rubocop:enable Style/ConditionalAssignment
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
+
+
+    # Checks equality by comparing each attribute.
+    # @param [Object] other the other object to be compared
+    def ==(other)
+      return true if equal?(other)
+
+      self.class == other.class &&
+        name == other.name &&
+        id == other.id &&
+        partitions == other.partitions &&
+        compartment_id == other.compartment_id &&
+        lifecycle_state == other.lifecycle_state &&
+        time_created == other.time_created &&
+        messages_endpoint == other.messages_endpoint &&
+        freeform_tags == other.freeform_tags &&
+        defined_tags == other.defined_tags
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
+
+    # @see the `==` method
+    # @param [Object] other the other object to be compared
+    def eql?(other)
+      self == other
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
+
+
+    # Calculates hash code according to all attributes.
+    # @return [Fixnum] Hash code
+    def hash
+      [name, id, partitions, compartment_id, lifecycle_state, time_created, messages_endpoint, freeform_tags, defined_tags].hash
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
+
+    # rubocop:disable Metrics/AbcSize, Layout/EmptyLines
+
+
+    # Builds the object from hash
+    # @param [Hash] attributes Model attributes in the form of hash
+    # @return [Object] Returns the model itself
+    def build_from_hash(attributes)
+      return nil unless attributes.is_a?(Hash)
+
+      self.class.swagger_types.each_pair do |key, type|
+        if type =~ /^Array<(.*)>/i
+          # check to ensure the input is an array given that the the attribute
+          # is documented as an array but the input is not
+          if attributes[self.class.attribute_map[key]].is_a?(Array)
+            public_method("#{key}=").call(
+              attributes[self.class.attribute_map[key]]
+                .map { |v| OCI::Internal::Util.convert_to_type(Regexp.last_match(1), v) }
+            )
+          end
+        elsif !attributes[self.class.attribute_map[key]].nil?
+          public_method("#{key}=").call(
+            OCI::Internal::Util.convert_to_type(type, attributes[self.class.attribute_map[key]])
+          )
+        end
+        # or else data not found in attributes(hash), not an issue as the data can be optional
+      end
+
+      self
+    end
+    # rubocop:enable Metrics/AbcSize, Layout/EmptyLines
+
+    # Returns the string representation of the object
+    # @return [String] String presentation of the object
+    def to_s
+      to_hash.to_s
+    end
+
+    # Returns the object in the form of hash
+    # @return [Hash] Returns the object in the form of hash
+    def to_hash
+      hash = {}
+      self.class.attribute_map.each_pair do |attr, param|
+        value = public_method(attr).call
+        next if value.nil? && !instance_variable_defined?("@#{attr}")
+
+        hash[param] = _to_hash(value)
+      end
+      hash
+    end
+
+    private
+
+    # Outputs non-array value in the form of hash
+    # For object, use to_hash. Otherwise, just return the value
+    # @param [Object] value Any valid value
+    # @return [Hash] Returns the value in the form of hash
+    def _to_hash(value)
+      if value.is_a?(Array)
+        value.compact.map { |v| _to_hash(v) }
+      elsif value.is_a?(Hash)
+        {}.tap do |hash|
+          value.each { |k, v| hash[k] = _to_hash(v) }
+        end
+      elsif value.respond_to? :to_hash
+        value.to_hash
+      else
+        value
+      end
+    end
+  end
+end
+# rubocop:enable Lint/UnneededCopDisableDirective

--- a/lib/oci/streaming/models/update_group_details.rb
+++ b/lib/oci/streaming/models/update_group_details.rb
@@ -4,44 +4,29 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
+  # Request body for operationally managing a group.
+  #
+  class Streaming::Models::UpdateGroupDetails # rubocop:disable Metrics/LineLength
+    TYPE_ENUM = [
+      TYPE_AT_TIME = 'AT_TIME'.freeze,
+      TYPE_LATEST = 'LATEST'.freeze,
+      TYPE_TRIM_HORIZON = 'TRIM_HORIZON'.freeze
+    ].freeze
+
+    # The type of the cursor.
     # @return [String]
-    attr_accessor :compartment_id
+    attr_reader :type
 
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
-    #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
-    # @return [String]
-    attr_accessor :display_name
-
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
-    #
-    # @return [Hash<String, String>]
-    attr_accessor :freeform_tags
-
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # The time to consume from if type is AT_TIME.
+    # @return [DateTime]
+    attr_accessor :time
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
-        'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'type': :'type',
+        'time': :'time'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +35,8 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
-        'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'type': :'String',
+        'time': :'DateTime'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,49 +47,30 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
-    # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [String] :type The value to assign to the {#type} property
+    # @option attributes [DateTime] :time The value to assign to the {#time} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
 
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
+      self.type = attributes[:'type'] if attributes[:'type']
 
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
-
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
-
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
-
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
-
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
-
-      self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
-
-      raise 'You cannot provide both :freeformTags and :freeform_tags' if attributes.key?(:'freeformTags') && attributes.key?(:'freeform_tags')
-
-      self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
-
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
-
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
-
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.time = attributes[:'time'] if attributes[:'time']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
+
+    # Custom attribute writer method checking allowed values (enum).
+    # @param [Object] type Object to be assigned
+    def type=(type)
+      # rubocop: disable Metrics/LineLength
+      raise "Invalid value for 'type': this must be one of the values in TYPE_ENUM." if type && !TYPE_ENUM.include?(type)
+
+      # rubocop: enable Metrics/LineLength
+      @type = type
+    end
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -118,11 +81,8 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
-        freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        type == other.type &&
+        time == other.time
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +98,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [type, time].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/models/update_stream_details.rb
+++ b/lib/oci/streaming/models/update_stream_details.rb
@@ -4,44 +4,29 @@ require 'date'
 
 # rubocop:disable Lint/UnneededCopDisableDirective
 module OCI
-  # CreateKeyDetails model.
-  class KeyManagement::Models::CreateKeyDetails # rubocop:disable Metrics/LineLength
-    # **[Required]** The OCID of the compartment that contains this key.
-    # @return [String]
-    attr_accessor :compartment_id
-
-    # Usage of predefined tag keys. These predefined keys are scoped to namespaces.
-    # Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+  # Object used to update a stream.
+  class Streaming::Models::UpdateStreamDetails # rubocop:disable Metrics/LineLength
+    # Free-form tags for this resource. Each tag is a simple key-value pair that is applied with no predefined name, type, or namespace. Exists for cross-compatibility only.
+    # For more information, see [Resource Tags](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm).
     #
-    # @return [Hash<String, Hash<String, Object>>]
-    attr_accessor :defined_tags
-
-    # **[Required]** A user-friendly name for the key. It does not have to be unique, and it is changeable.
-    # Avoid entering confidential information.
-    #
-    # @return [String]
-    attr_accessor :display_name
-
-    # Simple key-value pair that is applied without any predefined name, type, or scope.
-    # Exists for cross-compatibility only.
-    # Example: `{\"bar-key\": \"value\"}`
+    # Example: `{\"Department\": \"Finance\"}`
     #
     # @return [Hash<String, String>]
     attr_accessor :freeform_tags
 
-    # This attribute is required.
-    # @return [OCI::KeyManagement::Models::KeyShape]
-    attr_accessor :key_shape
+    # Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm).
+    #
+    # Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+    #
+    # @return [Hash<String, Hash<String, Object>>]
+    attr_accessor :defined_tags
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'compartmentId',
-        'defined_tags': :'definedTags',
-        'display_name': :'displayName',
         'freeform_tags': :'freeformTags',
-        'key_shape': :'keyShape'
+        'defined_tags': :'definedTags'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -50,11 +35,8 @@ module OCI
     def self.swagger_types
       {
         # rubocop:disable Style/SymbolLiteral
-        'compartment_id': :'String',
-        'defined_tags': :'Hash<String, Hash<String, Object>>',
-        'display_name': :'String',
         'freeform_tags': :'Hash<String, String>',
-        'key_shape': :'OCI::KeyManagement::Models::KeyShape'
+        'defined_tags': :'Hash<String, Hash<String, Object>>'
         # rubocop:enable Style/SymbolLiteral
       }
     end
@@ -65,34 +47,13 @@ module OCI
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    # @option attributes [String] :compartment_id The value to assign to the {#compartment_id} property
-    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
-    # @option attributes [String] :display_name The value to assign to the {#display_name} property
     # @option attributes [Hash<String, String>] :freeform_tags The value to assign to the {#freeform_tags} property
-    # @option attributes [OCI::KeyManagement::Models::KeyShape] :key_shape The value to assign to the {#key_shape} property
+    # @option attributes [Hash<String, Hash<String, Object>>] :defined_tags The value to assign to the {#defined_tags} property
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
-
-      self.compartment_id = attributes[:'compartmentId'] if attributes[:'compartmentId']
-
-      raise 'You cannot provide both :compartmentId and :compartment_id' if attributes.key?(:'compartmentId') && attributes.key?(:'compartment_id')
-
-      self.compartment_id = attributes[:'compartment_id'] if attributes[:'compartment_id']
-
-      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
-
-      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
-
-      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
-
-      self.display_name = attributes[:'displayName'] if attributes[:'displayName']
-
-      raise 'You cannot provide both :displayName and :display_name' if attributes.key?(:'displayName') && attributes.key?(:'display_name')
-
-      self.display_name = attributes[:'display_name'] if attributes[:'display_name']
 
       self.freeform_tags = attributes[:'freeformTags'] if attributes[:'freeformTags']
 
@@ -100,11 +61,11 @@ module OCI
 
       self.freeform_tags = attributes[:'freeform_tags'] if attributes[:'freeform_tags']
 
-      self.key_shape = attributes[:'keyShape'] if attributes[:'keyShape']
+      self.defined_tags = attributes[:'definedTags'] if attributes[:'definedTags']
 
-      raise 'You cannot provide both :keyShape and :key_shape' if attributes.key?(:'keyShape') && attributes.key?(:'key_shape')
+      raise 'You cannot provide both :definedTags and :defined_tags' if attributes.key?(:'definedTags') && attributes.key?(:'defined_tags')
 
-      self.key_shape = attributes[:'key_shape'] if attributes[:'key_shape']
+      self.defined_tags = attributes[:'defined_tags'] if attributes[:'defined_tags']
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Layout/EmptyLines, Style/SymbolLiteral
@@ -118,11 +79,8 @@ module OCI
       return true if equal?(other)
 
       self.class == other.class &&
-        compartment_id == other.compartment_id &&
-        defined_tags == other.defined_tags &&
-        display_name == other.display_name &&
         freeform_tags == other.freeform_tags &&
-        key_shape == other.key_shape
+        defined_tags == other.defined_tags
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/LineLength, Layout/EmptyLines
 
@@ -138,7 +96,7 @@ module OCI
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [compartment_id, defined_tags, display_name, freeform_tags, key_shape].hash
+      [freeform_tags, defined_tags].hash
     end
     # rubocop:enable Metrics/AbcSize, Metrics/LineLength, Layout/EmptyLines
 

--- a/lib/oci/streaming/stream_admin_client_composite_operations.rb
+++ b/lib/oci/streaming/stream_admin_client_composite_operations.rb
@@ -1,0 +1,143 @@
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+module OCI
+  # This class provides a wrapper around {OCI::Streaming::StreamAdminClient} and offers convenience methods
+  # for operations that would otherwise need to be chained together. For example, instead of performing an action
+  # on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+  # to enter a given state, you can call a single method in this class to accomplish the same functionality
+  class Streaming::StreamAdminClientCompositeOperations
+    # The {OCI::Streaming::StreamAdminClient} used to communicate with the service_client
+    #
+    # @return [OCI::Streaming::StreamAdminClient]
+    attr_reader :service_client
+
+    # Initializes a new StreamAdminClientCompositeOperations
+    #
+    # @param [OCI::Streaming::StreamAdminClient] service_client The client used to communicate with the service.
+    #   Defaults to a new service client created via {OCI::Streaming::StreamAdminClient#initialize} with no arguments
+    def initialize(service_client = OCI::Streaming::StreamAdminClient.new)
+      @service_client = service_client
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    # rubocop:disable Layout/EmptyLines
+
+
+    # Calls {OCI::Streaming::StreamAdminClient#create_stream} and then waits for the {OCI::Streaming::Models::Stream} acted upon
+    # to enter the given state(s).
+    #
+    # @param [OCI::Streaming::Models::CreateStreamDetails] create_stream_details The stream to create.
+    # @param [Array<String>] wait_for_states An array of states to wait on. These should be valid values for {OCI::Streaming::Models::Stream#lifecycle_state}
+    # @param [Hash] base_operation_opts Any optional arguments accepted by {OCI::Streaming::StreamAdminClient#create_stream}
+    # @param [Hash] waiter_opts Optional arguments for the waiter. Keys should be symbols, and the following keys are supported:
+    #   * max_interval_seconds: The maximum interval between queries, in seconds.
+    #   * max_wait_seconds The maximum time to wait, in seconds
+    #
+    # @return [OCI::Response] A {OCI::Response} object with data of type {OCI::Streaming::Models::Stream}
+    def create_stream_and_wait_for_state(create_stream_details, wait_for_states = [], base_operation_opts = {}, waiter_opts = {})
+      operation_result = @service_client.create_stream(create_stream_details, base_operation_opts)
+
+      return operation_result if wait_for_states.empty?
+
+      lowered_wait_for_states = wait_for_states.map(&:downcase)
+      wait_for_resource_id = operation_result.data.id
+
+      begin
+        waiter_result = @service_client.get_stream(wait_for_resource_id).wait_until(
+          eval_proc: ->(response) { response.data.respond_to?(:lifecycle_state) && lowered_wait_for_states.include?(response.data.lifecycle_state.downcase) },
+          max_interval_seconds: waiter_opts.key?(:max_interval_seconds) ? waiter_opts[:max_interval_seconds] : 30,
+          max_wait_seconds: waiter_opts.key?(:max_wait_seconds) ? waiter_opts[:max_wait_seconds] : 1200
+        )
+        result_to_return = waiter_result
+
+        return result_to_return
+      rescue StandardError
+        raise OCI::Errors::CompositeOperationError.new(partial_results: [operation_result])
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    # rubocop:enable Layout/EmptyLines
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    # rubocop:disable Layout/EmptyLines
+
+
+    # Calls {OCI::Streaming::StreamAdminClient#delete_stream} and then waits for the {OCI::Streaming::Models::Stream} acted upon
+    # to enter the given state(s).
+    #
+    # @param [String] stream_id The OCID of the stream to delete.
+    # @param [Array<String>] wait_for_states An array of states to wait on. These should be valid values for {OCI::Streaming::Models::Stream#lifecycle_state}
+    # @param [Hash] base_operation_opts Any optional arguments accepted by {OCI::Streaming::StreamAdminClient#delete_stream}
+    # @param [Hash] waiter_opts Optional arguments for the waiter. Keys should be symbols, and the following keys are supported:
+    #   * max_interval_seconds: The maximum interval between queries, in seconds.
+    #   * max_wait_seconds The maximum time to wait, in seconds
+    #
+    # @return [OCI::Response] A {OCI::Response} object with data of type nil
+    def delete_stream_and_wait_for_state(stream_id, wait_for_states = [], base_operation_opts = {}, waiter_opts = {})
+      initial_get_result = @service_client.get_stream(stream_id)
+      operation_result = @service_client.delete_stream(stream_id, base_operation_opts)
+
+      return operation_result if wait_for_states.empty?
+
+      lowered_wait_for_states = wait_for_states.map(&:downcase)
+
+      begin
+        waiter_result = initial_get_result.wait_until(
+          eval_proc: ->(response) { response.data.respond_to?(:lifecycle_state) && lowered_wait_for_states.include?(response.data.lifecycle_state.downcase) },
+          max_interval_seconds: waiter_opts.key?(:max_interval_seconds) ? waiter_opts[:max_interval_seconds] : 30,
+          max_wait_seconds: waiter_opts.key?(:max_wait_seconds) ? waiter_opts[:max_wait_seconds] : 1200,
+          succeed_on_not_found: true
+        )
+        result_to_return = waiter_result
+
+        return result_to_return
+      rescue StandardError
+        raise OCI::Errors::CompositeOperationError.new(partial_results: [operation_result])
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    # rubocop:enable Layout/EmptyLines
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    # rubocop:disable Layout/EmptyLines
+
+
+    # Calls {OCI::Streaming::StreamAdminClient#update_stream} and then waits for the {OCI::Streaming::Models::Stream} acted upon
+    # to enter the given state(s).
+    #
+    # @param [String] stream_id The OCID of the stream to update.
+    # @param [OCI::Streaming::Models::UpdateStreamDetails] update_stream_details The stream is updated with the tags provided.
+    # @param [Array<String>] wait_for_states An array of states to wait on. These should be valid values for {OCI::Streaming::Models::Stream#lifecycle_state}
+    # @param [Hash] base_operation_opts Any optional arguments accepted by {OCI::Streaming::StreamAdminClient#update_stream}
+    # @param [Hash] waiter_opts Optional arguments for the waiter. Keys should be symbols, and the following keys are supported:
+    #   * max_interval_seconds: The maximum interval between queries, in seconds.
+    #   * max_wait_seconds The maximum time to wait, in seconds
+    #
+    # @return [OCI::Response] A {OCI::Response} object with data of type {OCI::Streaming::Models::Stream}
+    def update_stream_and_wait_for_state(stream_id, update_stream_details, wait_for_states = [], base_operation_opts = {}, waiter_opts = {})
+      operation_result = @service_client.update_stream(stream_id, update_stream_details, base_operation_opts)
+
+      return operation_result if wait_for_states.empty?
+
+      lowered_wait_for_states = wait_for_states.map(&:downcase)
+      wait_for_resource_id = operation_result.data.id
+
+      begin
+        waiter_result = @service_client.get_stream(wait_for_resource_id).wait_until(
+          eval_proc: ->(response) { response.data.respond_to?(:lifecycle_state) && lowered_wait_for_states.include?(response.data.lifecycle_state.downcase) },
+          max_interval_seconds: waiter_opts.key?(:max_interval_seconds) ? waiter_opts[:max_interval_seconds] : 30,
+          max_wait_seconds: waiter_opts.key?(:max_wait_seconds) ? waiter_opts[:max_wait_seconds] : 1200
+        )
+        result_to_return = waiter_result
+
+        return result_to_return
+      rescue StandardError
+        raise OCI::Errors::CompositeOperationError.new(partial_results: [operation_result])
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    # rubocop:enable Layout/EmptyLines
+  end
+end
+# rubocop:enable Lint/UnneededCopDisableDirective, Metrics/LineLength

--- a/lib/oci/streaming/stream_client_composite_operations.rb
+++ b/lib/oci/streaming/stream_client_composite_operations.rb
@@ -1,0 +1,24 @@
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+module OCI
+  # This class provides a wrapper around {OCI::Streaming::StreamClient} and offers convenience methods
+  # for operations that would otherwise need to be chained together. For example, instead of performing an action
+  # on a resource (e.g. launching an instance, creating a load balancer) and then using a waiter to wait for the resource
+  # to enter a given state, you can call a single method in this class to accomplish the same functionality
+  class Streaming::StreamClientCompositeOperations
+    # The {OCI::Streaming::StreamClient} used to communicate with the service_client
+    #
+    # @return [OCI::Streaming::StreamClient]
+    attr_reader :service_client
+
+    # Initializes a new StreamClientCompositeOperations
+    #
+    # @param [OCI::Streaming::StreamClient] service_client The client used to communicate with the service.
+    #   Defaults to a new service client created via {OCI::Streaming::StreamClient#initialize} with no arguments
+    def initialize(service_client = OCI::Streaming::StreamClient.new)
+      @service_client = service_client
+    end
+  end
+end
+# rubocop:enable Lint/UnneededCopDisableDirective, Metrics/LineLength

--- a/lib/oci/streaming/streaming.rb
+++ b/lib/oci/streaming/streaming.rb
@@ -1,0 +1,35 @@
+# Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+
+module OCI
+  module Streaming
+    # Module containing models for requests made to, and responses received from,
+    # OCI Streaming services
+    module Models
+    end
+  end
+end
+
+# Require models
+require 'oci/streaming/models/create_cursor_details'
+require 'oci/streaming/models/create_group_cursor_details'
+require 'oci/streaming/models/create_stream_details'
+require 'oci/streaming/models/cursor'
+require 'oci/streaming/models/group'
+require 'oci/streaming/models/message'
+require 'oci/streaming/models/partition_reservation'
+require 'oci/streaming/models/put_messages_details'
+require 'oci/streaming/models/put_messages_details_entry'
+require 'oci/streaming/models/put_messages_result'
+require 'oci/streaming/models/put_messages_result_entry'
+require 'oci/streaming/models/stream'
+require 'oci/streaming/models/stream_summary'
+require 'oci/streaming/models/update_group_details'
+require 'oci/streaming/models/update_stream_details'
+
+# Require generated clients
+require 'oci/streaming/stream_client'
+require 'oci/streaming/stream_admin_client'
+require 'oci/streaming/stream_admin_client_composite_operations'
+
+# Require service utilities
+require 'oci/streaming/util'

--- a/lib/oci/streaming/util.rb
+++ b/lib/oci/streaming/util.rb
@@ -1,5 +1,2 @@
 # Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 
-module OCI
-  VERSION = '2.5.0'.freeze
-end

--- a/lib/oci/waas/waas_client.rb
+++ b/lib/oci/waas/waas_client.rb
@@ -25,20 +25,22 @@ module OCI
     # @return [String]
     attr_reader :region
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
 
     # Creates a new WaasClient.
     # Notes:
     #   If a config is not specified, then the global OCI.config will be used.
+    #
     #   This client is not thread-safe
     #
-    #   A region must be specified in either the config or the region parameter. If specified in both,
-    #   then the region parameter will be used.
-    #
+    #   Either a region or an endpoint must be specified.  If an endpoint is specified, it will be used instead of the
+    #     region. A region may be specified in the config or via or the region parameter. If specified in both, then the
+    #     region parameter will be used.
     # @param [Config] config A Config object.
     # @param [String] region A region used to determine the service endpoint. This will usually
     #   correspond to a value in {OCI::Regions::REGION_ENUM}, but may be an arbitrary string.
+    # @param [String] endpoint The fully qualified endpoint URL
     # @param [OCI::BaseSigner] signer A signer implementation which can be used by this client. If this is not provided then
     #   a signer will be constructed via the provided config. One use case of this parameter is instance principals authentication,
     #   so that the instance principals signer can be provided to the client
@@ -47,7 +49,7 @@ module OCI
     # @param [OCI::Retry::RetryConfig] retry_config The retry configuration for this service client. This represents the default retry configuration to
     #   apply across all operations. This can be overridden on a per-operation basis. The default retry configuration value is `nil`, which means that an operation
     #   will not perform any retries
-    def initialize(config: nil, region: nil, signer: nil, proxy_settings: nil, retry_config: nil)
+    def initialize(config: nil, region: nil, endpoint: nil, signer: nil, proxy_settings: nil, retry_config: nil)
       # If the signer is an InstancePrincipalsSecurityTokenSigner and no config was supplied (which is valid for instance principals)
       # then create a dummy config to pass to the ApiClient constructor. If customers wish to create a client which uses instance principals
       # and has config (either populated programmatically or loaded from a file), they must construct that config themselves and then
@@ -73,11 +75,16 @@ module OCI
       @api_client = OCI::ApiClient.new(config, signer, proxy_settings: proxy_settings)
       @retry_config = retry_config
 
-      region ||= config.region
-      region ||= signer.region if signer.respond_to?(:region)
-      self.region = region
+      if endpoint
+        @endpoint = endpoint + '/20181116'
+      else
+        region ||= config.region
+        region ||= signer.region if signer.respond_to?(:region)
+        self.region = region
+      end
+      logger.info "WaasClient endpoint set to '#{@endpoint}'." if logger
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Layout/EmptyLines, Metrics/PerceivedComplexity
 
     # Set the region that will be used to determine the service endpoint.
     # This will usually correspond to a value in {OCI::Regions::REGION_ENUM},
@@ -88,7 +95,7 @@ module OCI
       raise 'A region must be specified.' unless @region
 
       @endpoint = OCI::Regions.get_service_endpoint(@region, :WaasClient) + '/20181116'
-      logger.info "WaasClient endpoint set to '#{endpoint}'." if logger
+      logger.info "WaasClient endpoint set to '#{@endpoint} from region #{@region}'." if logger
     end
 
     # @return [Logger] The logger for this client. May be nil.

--- a/oci.gemspec
+++ b/oci.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0', '>= 0.55'
   s.add_development_dependency 'mocha', '~> 1.7'
   s.add_development_dependency 'nokogiri', '~> 1.9'
-
+  s.add_development_dependency 'rspec', '~> 3.8'
+  s.add_development_dependency 'activesupport', '~> 5.2.2'
   s.executables   = nil
   s.require_paths = ["lib"]
   s.files         = Dir["./lib/**/*.rb", "README.md", "LICENSE.txt"]


### PR DESCRIPTION
### Added
- Support for government-realm regions
- Support for the Streaming service
- Support for tags in the Key Management service
- Support for regional subnets in the Virtual Networking service
- Support for specifying an optional `endpoint` parameter when creating a new client

### Fixed
- Removed unused Announcements service `OCI::AnnouncementsService::Models::NotificationFollowupDetails` model and `followups` from `OCI::AnnouncementsService::Models::Announcement`
